### PR TITLE
Export Dict and AnyDict macros

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -16,4 +16,5 @@ else
     end
 end
 
+export @Dict, @AnyDict
 end # module


### PR DESCRIPTION
Not sure if this was intended or not, but the macros in this package aren't exported. This pull request exports them.
