### PR TITLE
Added TypedDict

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -7,6 +7,9 @@ if VERSION < v"0.4.0-dev+980"
     macro AnyDict(pairs...)
         esc(Expr(:typed_dict, :(Any=>Any), pairs...))
     end
+    macro TypedDict(T, pairs...)
+        esc(Expr(:typed_dict, T, pairs...))
+    end
 else
     macro Dict(pairs...)
         esc(Expr(:call, :Dict, pairs...))


### PR DESCRIPTION
Important to me, as sometimes I need [:a=>23, :b=>22] to be of type (Symbol => Any).
Also, it's needed for initializing an empty typed dict.
