### PR TITLE
itrunc/iceil/ifloor(Int,x::Integer) not defined in 0.3

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -37,7 +37,7 @@ import Base: round, ceil, floor, trunc
 if VERSION < v"0.4.0-dev+1827"
     for (fnew,fold) in ((:round, :iround), (:ceil, :iceil), (:floor, :ifloor), (:trunc, :itrunc))
         @eval begin
-            ($fnew){T<:Integer}(::Type{T}, x::Integer) = ($fold)(T, x)  # ambiguity resolution with digits/base version
+            ($fnew){T<:Integer}(::Type{T}, x::Integer) = convert(T, x)  # ambiguity resolution with digits/base version, not all old methods defined
             ($fnew){T<:Integer}(::Type{T}, x) = ($fold)(T, x)
         end
     end


### PR DESCRIPTION
changes `trunc(Int,x::Integer)` to `convert(T,x)`
