### PR TITLE
Fix #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `itrunc`, `iround`, `iceil`, `ifloor` are now accessed via `trunc(T, x)`, etc. [#9133](https://github.com/JuliaLang/julia/pull/9133)
 
 * `Base.Random.randmtzig_exprnd` is now `randexp` [#9144](https://github.com/JuliaLang/julia/pull/9144)
+
+## Other syntax changes
+
+* `Dict(ks, vs)` is now `Dict(zip(ks, vs))` [#8521](https://github.com/JuliaLang/julia/pull/8521)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -24,6 +24,10 @@ if VERSION < v"0.4.0-dev+980"
     macro AnyDict(pairs...)
         esc(Expr(:typed_dict, :(Any=>Any), pairs...))
     end
+
+    Base.Dict(kv) = dict_with_eltype(kv, eltype(kv))
+    dict_with_eltype{K,V}(kv, ::Type{(K,V)}) = Dict{K,V}(kv)
+    dict_with_eltype(kv, t) = Dict{Any,Any}(kv)
 else
     macro Dict(pairs...)
         esc(Expr(:call, :Dict, pairs...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,9 @@ d2[:a] = Dict{Symbol,Int}()
 d2[:a][:b] = 1
 @test @compat(Dict(:a => Dict(:b => 1))) == d2
 
+d = Dict(zip([1, 2], [3, 4]))
+@test d == @compat Dict(1=>3, 2=>4)
+
 @compat function f()
 	a = :a
 	b = Dict(:b => 1)


### PR DESCRIPTION
This just backports the relevant code from `dict.jl`.
