### PR TITLE
adds Nullable to Compat

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -118,6 +118,11 @@ if VERSION < v"0.4.0-dev+2056"
     end
 end
 
+if VERSION < v"0.4.0-dev+656"
+    export Nullable, isnull
+    include("nullable.jl")
+end
+
 function _compat(ex::Expr)
     if ex.head == :call
         f = ex.args[1]

--- a/src/nullable.jl
+++ b/src/nullable.jl
@@ -1,0 +1,60 @@
+import Base: eltype, convert, show, get, isequal, ==, hash
+
+immutable Nullable{T}
+    isnull::Bool
+    value::T
+
+    Nullable() = new(true)
+    Nullable(value::T) = new(false, value)
+end
+
+immutable NullException <: Exception
+end
+
+Nullable{T}(value::T) = Nullable{T}(value)
+
+eltype{T}(::Type{Nullable{T}}) = T
+
+eltype{T}(x::Nullable{T}) = T
+
+function convert{T}(::Type{Nullable{T}}, x::Nullable)
+    return isnull(x) ? Nullable{T}() : Nullable(convert(T, get(x)))
+end
+
+convert{T}(::Type{Nullable{T}}, x::T) = Nullable{T}(x)
+
+function show{T}(io::IO, x::Nullable{T})
+    if x.isnull
+        @printf(io, "Nullable{%s}()", repr(T))
+    else
+        @printf(io, "Nullable(%s)", repr(x.value))
+    end
+end
+
+get(x::Nullable) = x.isnull ? throw(NullException()) : x.value
+
+get{T}(x::Nullable{T}, y) = x.isnull ? convert(T, y) : x.value
+
+isnull(x::Nullable) = x.isnull
+
+function isequal(x::Nullable, y::Nullable)
+    if x.isnull && y.isnull
+        return true
+    elseif x.isnull || y.isnull
+        return false
+    else
+        return isequal(x.value, y.value)
+    end
+end
+
+==(x::Nullable, y::Nullable) = throw(NullException())
+
+const nullablehash_seed = UInt === UInt64 ? 0x932e0143e51d0171 : 0xe51d0171
+
+function hash(x::Nullable, h::UInt)
+    if x.isnull
+        return h + nullablehash_seed
+    else
+        return hash(x.value, h + nullablehash_seed)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,3 +65,10 @@ ns = length(d.slots)
 if VERSION < v"0.4.0-dev+1387"
     @test isdefined(Main, :AbstractString)
 end
+
+if VERSION < v"0.4.0-dev+656"
+    @test isdefined(Main, :Nullable)
+    @test isdefined(Main, :isnull)
+
+    @test isnull(Nullable{Float64}())
+end


### PR DESCRIPTION
I am developing a julia interface to Postgres and found myself in need of Nullables for Juliav `v0.3`. Instead of rolling my own variant of it I thought it best to add the Nullable implementation from `v0.4` to `Compat.jl`
