### PR TITLE
Support rounding of rationals

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -43,6 +43,7 @@ if VERSION < v"0.4.0-dev+1827"
         @eval begin
             ($fnew){T<:Integer}(::Type{T}, x::Integer) = convert(T, x)  # ambiguity resolution with digits/base version, not all old methods defined
             ($fnew){T<:Integer}(::Type{T}, x) = ($fold)(T, x)
+            ($fnew){T<:Integer}(::Type{T}, x::Rational) = convert(T, ($fold)(x)) # no e.g. iround(::Type{T}, x::Rational) is defined in 0.3
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,3 +65,5 @@ ns = length(d.slots)
 if VERSION < v"0.4.0-dev+1387"
     @test isdefined(Main, :AbstractString)
 end
+
+@test round(Int, 3//4) == 1


### PR DESCRIPTION
Before this PR (on Julia 0.3):

```
julia> using Compat

julia> round(Int, 1//2)
ERROR: `iround` has no method matching iround(::Type{Int64}, ::Rational{Int64})
 in round at /home/tlycken/.julia/v0.3/Compat/src/Compat.jl:45
```

After this PR:

```
julia> using Compat

julia> round(Int, 1//2)
1
```
