### PR TITLE
randbool() -> rand(Bool) and birand()

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -134,6 +134,15 @@ if VERSION < v"0.4.0-dev+2056"
     end
 end
 
+if VERSION < v"0.4.0-dev+2440"
+    bitrand(r::AbstractRNG, dims::Dims)   = rand!(r, BitArray(dims))
+    bitrand(r::AbstractRNG, dims::Int...) = rand!(r, BitArray(dims))
+    bitrand(dims::Dims)   = rand!(BitArray(dims))
+    bitrand(dims::Int...) = rand!(BitArray(dims))
+    export bitrand
+    Base.rand(::Type{Bool}) = randbool()
+end
+
 if VERSION < v"0.4.0-dev+2485"
     startswith = Base.beginswith
     export startswith

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,3 +74,9 @@ end
 
 @test startswith("abcdef","abc") == true
 @test startswith("abcdef","def") == false
+
+@test size(bitrand(3, 4)) == (3, 4)
+@test size(bitrand((3, 4))) == (3, 4)
+@test size(bitrand(MersenneTwister(), 3, 4)) == (3, 4)
+@test size(bitrand(MersenneTwister(), (3, 4))) == (3, 4)
+@test rand(Bool) in [false, true]


### PR DESCRIPTION
adds the new names for the methods which replaced `randbool`.