### PR TITLE
Handle arrays in rounding functions

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -65,6 +65,13 @@ if VERSION < v"0.4.0-dev+1827"
             ($fnew){T<:Integer}(::Type{T}, x::Integer) = convert(T, x)  # ambiguity resolution with digits/base version, not all old methods defined
             ($fnew){T<:Integer}(::Type{T}, x) = ($fold)(T, x)
             ($fnew){T<:Integer}(::Type{T}, x::Rational) = convert(T, ($fold)(x)) # no e.g. iround(::Type{T}, x::Rational) is defined in 0.3
+            function ($fnew){T<:Integer}(::Type{T}, x::AbstractArray)
+                r = Array(T,size(x))
+                for i = 1:length(x)
+                    r[i] = ($fold)(x[i])
+                end
+                r
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,11 @@ if VERSION < v"0.4.0-dev+1387"
 end
 
 @test round(Int, 3//4) == 1
+for x in [(round, iround), (ceil, iceil), (floor, ifloor), (trunc, itrunc)]
+    for v = Any[1, 1.1, [1,1], [1.1, 1.1], [1 1], [1.1 1.1]]
+        @test x[1](Int,v) == x[2](v)
+    end
+end
 
 @test IPv4("1.2.3.4") == ip"1.2.3.4"
 @test IPv6("2001:1:2:3::1") == ip"2001:1:2:3::1"


### PR DESCRIPTION
In v0.3, only `iround` is able to deal with arrays when a type is specified:

```jl
using Compat
julia> round(Integer,[1.0,2.0])
2-element Array{Int64,1}:
 1
 2
julia> ceil(Integer,[1.0,2.0])
ERROR: `iceil` has no method matching iceil(::Type{Integer}, ::Array{Float64,1})
 in ceil at /Users/rene/.julia/v0.3/Compat/src/Compat.jl:66
```
This PR defines a new compatibility function for arrays, making the above pass (like in v0.4)