### PR TITLE
Add compat for unsafe_convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `parseint` and `parsefloat` are now `parse(T, ...)` [#10543](https://github.com/JuliaLang/julia/pull/10543)
 
+* `convert(::Ptr{T}, x)` is now `Base.unsafe_convert` [#9986](https://github.com/JuliaLang/julia/pull/9986).
+  Compat provides an unexported `Compat.unsafe_convert` method that is aliased to `Base.convert` on Julia 0.3 and
+  `Base.unsafe_convert` on Julia 0.4.
+
 ## New macros
 
 * `@inline` and `@noinline` have been added. On 0.3, these are "no-ops," meaning they don't actually do anything.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -198,6 +198,12 @@ if VERSION < v"0.4.0-dev+3874"
     Base.parse{T<:Union(Float32,Float64)}(::Type{T}, s::AbstractString) = parsefloat(T, s)
 end
 
+if VERSION < v"0.4.0-dev+3710"
+    const unsafe_convert = Base.convert
+else
+    import Base.unsafe_convert
+end
+
 if VERSION < v"0.4.0-dev+3732"
     const calltypes = Dict{Symbol,Symbol}()
     for (k,v) in [(:Integer,:integer),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,3 +167,10 @@ end
 for x in [:RTLD_LOCAL,:RTLD_GLOBAL,:find_library,:dlsym,:RTLD_LAZY,:RTLD_NODELETE,:DL_LOAD_PATH,:RTLD_NOW,:Libdl,:dlext,:dlsym_e,:RTLD_FIRST,:dlopen,:dllist,:dlpath,:RTLD_NOLOAD,:dlclose,:dlopen_e,:RTLD_DEEPBIND]
     Libdl.(x)
 end
+
+# Test unsafe_convert
+type A; end
+x = "abc"
+@test bytestring(Compat.unsafe_convert(Ptr{UInt8}, x)) == x
+Compat.unsafe_convert(::Ptr{A}, x) = x
+@test Compat.unsafe_convert(pointer([A()]), 1) == 1


### PR DESCRIPTION
This is unexported from Base, but this way packages can `import Compat.unsafe_convert`