### PR TITLE
WIP: atsign-compat for Tuple{a, b} syntax

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -261,6 +261,11 @@ function _compat(ex::Expr)
         elseif VERSION < v"0.4.0-dev+1419" && isexpr(f, :curly) && f.args[1] == :Ptr && length(ex.args) == 2 && ex.args[2] == 0
             ex = Expr(:call, :zero, f)
         end
+    elseif ex.head == :curly
+        f = ex.args[1]
+        if VERSION < v"0.4.0-dev+4319" && f == :Tuple
+            ex = Expr(:tuple, ex.args[2:end]...)
+        end
     end
     return Expr(ex.head, map(_compat, ex.args)...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,3 +209,11 @@ Compat.unsafe_convert(::Ptr{A}, x) = x
 
 # Test Ptr{T}(0)
 @test @compat(Ptr{Int}(0)) == C_NULL
+
+# Test Tuple{} syntax
+if VERSION < v"0.4.0-dev+4319"
+    @test @compat Tuple{1} == (1,)
+    @test @compat Tuple{:a, :b} == (:a, :b)
+    @test @compat Tuple{:a, Tuple{:b}} == (:a, (:b,))
+    @test @compat Tuple{:a, Tuple{:b, :c}} == (:a, (:b, :c))
+end


### PR DESCRIPTION
first attempt at making `@compat` handle the new tuple syntax from https://github.com/JuliaLang/julia/pull/10380 - putting this up immediately for feedback