### PR TITLE
add Cstring/Cwstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * For all unsigned integer types to their equivalents with uppercase `I`. [#8907](https://github.com/JuliaLang/julia/pull/8907)
 
+* `Cstring` and `Cwstring` for `Ptr{Cchar}` and `Ptr{Cwchar_t}`, respectively:
+  these should be used for passing NUL-terminated strings to `ccall`.  (In
+  Julia 0.4, using these types also checks whether the string has embedded
+  NUL characters [#10994](https://github.com/JuliaLang/julia/pull/10994).)
+
 ## New functions
 
 * `eachindex`, as in `for i in eachindex(A)`, can be used in julia 0.3. This is the recommended way to iterate over each index in an `AbstractArray`. On julia 0.3 `eachindex` just returns `1:length(A)`, but in julia 0.4 it can return a more sophisticated iterator. 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -382,4 +382,12 @@ if VERSION < v"0.4.0-dev+2254"
     export Val
 end
 
+if VERSION < v"0.4.0-dev+4603"
+    # used for C string arguments to ccall
+    # (in Julia 0.4, these types also check for embedded NUL chars)
+    const Cstring = Ptr{Cchar}
+    const Cwstring = Ptr{Cwchar_t}
+    export Cstring, Cwstring
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,3 +289,9 @@ begin
     @test firstlast(Val{true}) == "First"
     @test firstlast(Val{false}) == "Last"
 end
+
+# Cstring
+let s = "foo", w = wstring("foo")
+    @test reinterpret(Ptr{Cchar}, Compat.unsafe_convert(Cstring, s)) == pointer(s)
+    @test reinterpret(Ptr{Cwchar_t}, Compat.unsafe_convert(Cwstring, w)) == pointer(w)
+end


### PR DESCRIPTION
 This provides compatibility for the new types introduced in JuliaLang/julia#10994.

(In older versions, they are just aliases for `Ptr{Cchar}` and `Ptr{Cwchar_t}`.)