### PR TITLE
Add AssertionError as typealias of ExceptionError

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `typealias AbstractString String` - `String` has been renamed to `AbstractString` [#8872](https://github.com/JuliaLang/julia/pull/8872)
 
+* `typealias AssertionError ErrorException` - `AssertionError` was introduced in [##9734](https://github.com/JuliaLang/julia/pull/#9734); before `@assert` threw an `ErrorException`
+
 * For all unsigned integer types to their equivalents with uppercase `I`. [#8907](https://github.com/JuliaLang/julia/pull/8907)
 
 ## New functions

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -28,6 +28,11 @@ if VERSION < v"0.4.0-dev+1387"
     export AbstractString
 end
 
+if VERSION < v"0.4.0-dev+3324"
+    typealias AssertionError ErrorException
+    export AssertionError
+end
+
 if VERSION < v"0.4.0-dev+412"
     eval(Base, :(const IPAddr = IpAddr))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Compat
 using Base.Test
 
 v = 1
+@test_throws AssertionError @assert(v < 1)
 
 d = Dict{Int,Int}()
 d[1] = 1


### PR DESCRIPTION
`AssertionError` was introduced in https://github.com/JuliaLang/julia/pull/9734; previously, `@assert` threw an `ErrorException`. This commit adds `AssertionError` as typealias, with a trivial test, and a sentence to README.md.