### PR TITLE
Convert generated function -> stagedfunction for older julia 0.4

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -293,6 +293,14 @@ function _compat(ex::Expr)
                 Expr(:tuple, args...)
             end
         end
+    elseif ex.head == :macrocall
+        f = ex.args[1]
+        if f == symbol("@generated") && VERSION < v"0.4.0-dev+4387"
+            f = ex.args[2]
+            if isexpr(f, :function)
+                ex = Expr(:stagedfunction, f.args...)
+            end
+        end
     end
     return Expr(ex.head, map(_compat, ex.args)...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,3 +327,12 @@ let A = rand(2,2)
     U = @compat chol(B, Val{:U})
     @test_approx_eq U'*U B
 end
+
+# @generated
+let
+    @compat @generated function foo(x)
+        T = x
+        :(return $T)
+    end
+    @test foo(5) == Int
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,10 +329,12 @@ let A = rand(2,2)
 end
 
 # @generated
-let
-    @compat @generated function foo(x)
-        T = x
-        :(return $T)
+if VERSION > v"0.3.99"
+    let
+        @compat @generated function foo(x)
+            T = x
+            :(return $T)
+        end
+        @test foo(5) == Int
     end
-    @test foo(5) == Int
 end


### PR DESCRIPTION
This is mildly silly, perhaps, and I won't object if people don't think this should be merged. But I have one machine running an older version of 0.4, and adding support for `@generated function` (translating it back into `stagedfunction`) was one of the only missing items.