### PR TITLE
at-compat for Vector{T}(), Vector{T}(n), Array{T}  (fixes #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat f(t::Timer)` - mimic the Julia 0.4 Timer class
 
+* `@compat Vector{Int}()`, `@compat Vector{UInt8}(n)`, `@compat Array{Float32}(2,2)` - Julia 0.4-style array constructors.
+
 ## Type Aliases
 
 * `typealias AbstractString String` - `String` has been renamed to `AbstractString` [#8872](https://github.com/JuliaLang/julia/pull/8872)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -279,6 +279,12 @@ function _compat(ex::Expr)
             if isexpr(s, :curly) && s.args[1] == :Val
                 ex = Expr(:call, :chol, ex.args[2], s.args[2])
             end
+        elseif VERSION < v"0.4.0-dev+4739" && isexpr(f, :curly) && (f.args[1] == :Vector || f.args[1] == :Array)
+            if f.args[1] == :Vector && length(ex.args) == 1
+                ex = Expr(:call, :Array, f.args[2], 0)
+            else
+                ex = Expr(:call, :Array, f.args[2], ex.args[2:end]...)
+            end
         end
     elseif ex.head == :curly
         f = ex.args[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,3 +367,26 @@ Compat.@irrational mathconst_one 1.0 big(1.)
 # gc_enable(::Bool)
 @test gc_enable(false)
 @test !gc_enable(true)
+
+# Vector{Int}(), Array{Int}
+
+@test @compat typeof(Vector{Int}()) == Array{Int,1}
+@test @compat length(Vector{Int}()) == 0
+
+@test @compat typeof(Vector{Int8}(10)) == Array{Int8,1}
+@test @compat length(Vector{Int8}(10)) == 10
+
+@test @compat typeof(Array{UInt16}()) == Array{UInt16,0}
+@test @compat length(Array{UInt16}()) == 1
+
+@test @compat typeof(Array{UInt16}(0)) == Array{UInt16,1}
+@test @compat length(Array{UInt16}(0)) == 0
+
+@test @compat typeof(Array{Float16}(5)) == Array{Float16,1}
+@test @compat length(Array{Float16}(5)) == 5
+
+@test @compat typeof(Array{String}(2,2)) == Array{String,2}
+@test @compat size(Array{String}(2,2)) == (2,2)
+
+@test @compat typeof(Array{Rational{Int}}(2,2,2,2,2)) == Array{Rational{Int},5}
+@test @compat size(Array{Rational{Int}}(2,2,2,2,2)) == (2,2,2,2,2)


### PR DESCRIPTION
Cc: @sbromberger 