### PR TITLE
Added Compat for DataStructures.OrderedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ wherever you want to use syntax that differs in the latest Julia
 
 Currently, the `@compat` macro supports the following syntaxes:
 
-* `@compat Dict(foo => bar, baz => qux)` - type-inferred `Dict` construction.
+* `@compat Dict(foo => bar, baz => qux)` - type-inferred `Dict` construction. (Also works for DataStructures.OrderedDict)
 
-* `@compat Dict{Foo,Bar}(foo => bar, baz => qux)` - type-declared `Dict` construction.
+* `@compat Dict{Foo,Bar}(foo => bar, baz => qux)` - type-declared `Dict` construction. (Also works for DataStructures.OrderedDict)
 
 * `@compat split(str, splitter; keywords...)` - the Julia 0.4-style keyword-based `split` function
 


### PR DESCRIPTION
* OrderedDict construction has been changed to match Dict construction
  in Base.  This change allows `@compat OrderedDict{...}(...)` to be
  used on v0.3 (and early versions of v0.4)

`OrderedDict` is in DataStructures.jl, which is part of the JuliaLang organization, so it still seems appropriate to me to add this to Compat.jl.  But I'm willing to hear arguments otherwise.

The alternative would be to create a separate macro in DataStructures.jl (see https://github.com/JuliaLang/DataStructures.jl/pull/105) and ask users to use that macro instead of `@compat`, which is awkward, but doable.
