### PR TITLE
compat for MemoryError -> OutOfMemoryError change

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -480,4 +480,9 @@ if VERSION < v"0.4.0-dev+5305"
     end
 end
 
+if VERSION < v"0.4.0-dev+3837" # JuliaLang/julia#10503
+    const OutOfMemoryError = MemoryError
+    export OutOfMemoryError
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,3 +390,5 @@ Compat.@irrational mathconst_one 1.0 big(1.)
 
 @test @compat typeof(Array{Rational{Int}}(2,2,2,2,2)) == Array{Rational{Int},5}
 @test @compat size(Array{Rational{Int}}(2,2,2,2,2)) == (2,2,2,2,2)
+
+@test isa(OutOfMemoryError(), Exception)


### PR DESCRIPTION
This adds compatibility for JuliaLang/julia#10503 (I just noticed this in PyCall; there is no deprecation warning because it is a type rename).