### PR TITLE
compat for JuliaLang/julia#12472

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `typealias AbstractString String` - `String` has been renamed to `AbstractString` [#8872](https://github.com/JuliaLang/julia/pull/8872)
 
+* `typealias AbstractFloat FloatingPoint` - `FloatingPoint` has been renamed to `AbstractFloat` [#12162](https://github.com/JuliaLang/julia/pull/12162)
+
 * `typealias AssertionError ErrorException` - `AssertionError` was introduced in [#9734](https://github.com/JuliaLang/julia/pull/9734); before `@assert` threw an `ErrorException`
 
 * For all unsigned integer types to their equivalents with uppercase `I`. [#8907](https://github.com/JuliaLang/julia/pull/8907)
@@ -83,6 +85,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `__precompile(iscompiled::Bool)__` and `include_dependency(path::AbstractString)` allow
   Julia 0.4 precompilation information to be provided (with no effect in earlier versions).
   (However, to enable precompiling in 0.4, it is better to explicitly put `VERSION >= v"0.4.0-dev+6521" && __precompile__()` before your `module` statement, so that Julia knows to precompile before anything in your module is evaluated.)
+
+* `isapprox(A, B)` for arrays ([JuliaLang/julia#12472](https://github.com/JuliaLang/julia/pull/12472)), and synonyms `≈` ([U+2248](http://www.fileformat.info/info/unicode/char/2248/index.htm), LaTeX `\approx`) and `≉` ([U+2249](http://www.fileformat.info/info/unicode/char/2249/index.htm), LaTeX `\napprox`) for `isapprox` and `!isapprox`, respectively.
 
 ## Renamed functions
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -543,4 +543,27 @@ if VERSION < v"0.4.0-dev+6506"
     export include_dependency
 end
 
+if VERSION < v"0.4.0-dev+6425"
+    typealias AbstractFloat FloatingPoint
+    export AbstractFloat
+end
+
+if VERSION < v"0.4.0-dev+6068"
+    Base.real{T<:Real}(::Type{T}) = T
+    Base.real{T<:Real}(::Type{Complex{T}}) = T
+end
+
+if VERSION < v"0.4.0-dev+6578"
+    rtoldefault{T<:AbstractFloat}(::Type{T}) = sqrt(eps(T))
+    rtoldefault{T<:Real}(::Type{T}) = 0
+    rtoldefault{T<:Number,S<:Number}(x::Union(T,Type{T}), y::Union(S,Type{S})) = rtoldefault(promote_type(real(T),real(S)))
+    function Base.isapprox{T<:Number,S<:Number}(x::AbstractArray{T}, y::AbstractArray{S}; rtol::Real=rtoldefault(T,S), atol::Real=0, norm::Function=vecnorm)
+        d = norm(x - y)
+        return isfinite(d) ? d <= atol + rtol*max(norm(x), norm(y)) : x == y
+    end
+    const ≈ = isapprox
+    ≉(x,y) = !(x ≈ y)
+    export ≈, ≉
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -412,3 +412,11 @@ Compat.@irrational mathconst_one 1.0 big(1.)
 
 @test nothing === __precompile__(false) # tests should never be precompiled
 @test nothing === include_dependency("foo")
+
+@test real(Int) == real(Complex{Int}) == Int
+
+@test isa(1.2, AbstractFloat)
+
+@test [1,2,3] ≈ [1,2,3+1e-9]
+@test [0,1] ≈ [1e-9, 1]
+@test [0,1] ≉ [1e-3, 1]


### PR DESCRIPTION
This adds the new `isapprox` array functions and binary operators from JuliaLang/julia#12472.

It also added the new `real(T)` methods from JuliaLang/julia#12201, which were needed for `rtoldefault`.

I also needed to fix #121 by adding `AbstractFloat`