### PR TITLE
Add macro for conditionally choosing code based on Julia version

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -566,4 +566,14 @@ if VERSION < v"0.4.0-dev+6578"
     export ≈, ≉
 end
 
+macro julia_geq(ex)
+    (Base.Meta.isexpr(ex, :if) && length(ex.args) == 3) ||
+        throw(ArgumentError("invalid syntax"))
+    version = ex.args[1]
+    (Base.Meta.isexpr(version, :macrocall) && length(version.args) == 2 && version.args[1] === symbol("@v_str")) ||
+        throw(ArgumentError("invalid syntax"))
+    VERSION >= convert(VersionNumber, version.args[2]) ? esc(ex.args[2]) : esc(ex.args[3])
+end
+export @julia_geq
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -420,3 +420,9 @@ Compat.@irrational mathconst_one 1.0 big(1.)
 @test [1,2,3] ≈ [1,2,3+1e-9]
 @test [0,1] ≈ [1e-9, 1]
 @test [0,1] ≉ [1e-3, 1]
+
+passed = false
+@julia_geq v"0.1-" ? (passed = true) : error("@julia_geq test failed")
+@test passed
+passed = false
+@julia_geq v"100" ? error("@julia_geq test failed") : (passed = true)


### PR DESCRIPTION
Some things, like uses of the old FFT API, are difficult/never exported/not used widely enough to define in Compat. However, when it's necessary to select different code based on the Julia version within a function, comparing `VERSION` directly is a bad idea because it incurs a runtime cost and also potentially screws with type inference. This PR defines a `@julia_geq` macro that works like:

```julia
function f()
    x = @julia_geq v"0.4.0-dev+6632" ? 1 : 2.0
    x + 1
end
```

It can also be used with blocks:

```julia
function f()
    @julia_geq v"0.4.0-dev+6632" ? begin
        ...
    end : begin
        ...
     end
end
```

I'm open to bikeshedding both the name and the syntax, but since I'm already using something like this in DSP, I figured it might be useful enough to include here.