### PR TITLE
eliminate a couple of deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * For all unsigned integer types to their equivalents with uppercase `I`. [#8907](https://github.com/JuliaLang/julia/pull/8907)
 
-* `Cstring` and `Cwstring` for `Ptr{Cchar}` and `Ptr{Cwchar_t}`, respectively:
+* `Cstring` and `Cwstring` for `Ptr{UInt8}` and `Ptr{Cwchar_t}`, respectively:
   these should be used for passing NUL-terminated strings to `ccall`.  (In
   Julia 0.4, using these types also checks whether the string has embedded
   NUL characters [#10994](https://github.com/JuliaLang/julia/pull/10994).)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -444,7 +444,7 @@ end
 if VERSION < v"0.4.0-dev+4603"
     # used for C string arguments to ccall
     # (in Julia 0.4, these types also check for embedded NUL chars)
-    const Cstring = Ptr{Cchar}
+    const Cstring = Ptr{UInt8}
     const Cwstring = Ptr{Cwchar_t}
     export Cstring, Cwstring
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,9 +320,9 @@ end
 
 # is_valid_utf32
 s = utf32("abc")
-@test is_valid_utf32(s)
+@test isvalid(s)
 s = utf32(UInt32[65,0x110000])
-@test !is_valid_utf32(s)
+@test !isvalid(s)
 
 # isvalid
 let s = "abcdef", u8 = "abcdef\uff", u16 = utf16(u8), u32 = utf32(u8),


### PR DESCRIPTION
Don't call `is_valid_utf32` directly from the tests, since it is deprecated in 0.4.  Call `isvalid` instead, since that calls our `is_valid_utf32` on Julia 0.3.

Also, make `Cstring` an alias for `Ptr{UInt8}` rather than `Ptr{Cchar}`, to eliminate
```
WARNING: (convert{T})(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
```
when passing a `ByteString` (which is an array of `UInt8`).