### PR TITLE
Ignore quote Exprs in @ compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat Void` - `Nothing` on 0.3 (`Ptr{Void}` is not changed).
 
+* `@compat Union{args...}` - `Union(args...)` on 0.3. [#11432](https://github.com/JuliaLang/julia/pull/11432)
+
 ## Type Aliases
 
 * `typealias AbstractString String` - `String` has been renamed to `AbstractString` [#8872](https://github.com/JuliaLang/julia/pull/8872)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -438,6 +438,9 @@ function _compat(ex::Expr)
         if ex.args[end] == :Timer || ex.args[end] == :(Base.Timer)
             ex.args[end] = :(Compat.Timer2)
         end
+    elseif ex.head == :quote && isa(ex.args[1], Symbol)
+        # Passthrough
+        return ex
     end
     return Expr(ex.head, map(_compat, ex.args)...)
 end

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -419,7 +419,7 @@ function _compat(ex::Expr)
             else
                 Expr(:tuple, args...)
             end
-        elseif VERSION < v"0.4.0-dev" && f == :Union
+        elseif VERSION < v"0.4.0-dev+5379" && f == :Union
             ex = Expr(:call,:Union,ex.args[2:end]...)
         elseif ex == :(Ptr{Void})
             # Do no change Ptr{Void} to Ptr{Nothing}: 0.4.0-dev+768

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,9 +31,8 @@ td[1] = 1.0
 
 @test @compat(Dict()) == Dict()
 @test @compat(Dict{Any,Any}()) == Dict{Any,Any}()
-if VERSION >= v"0.3.0-"
-    @test @compat(Dict([(1, 1)])) == d
-end
+@test @compat(Dict([(1, 1)])) == d
+@test @compat(Dict(:Void => :Nothing)) == Dict([(:Void, :Nothing)])
 
 d2 = Dict{Symbol,Dict{Symbol,Int}}()
 d2[:a] = Dict{Symbol,Int}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -542,3 +542,10 @@ f141(::Type{UDPSocket}) = true
 @test f141(OutOfMemoryError)
 @test f141(Base64EncodePipe)
 @test f141(UDPSocket)
+
+# Union syntax
+if VERSION < v"0.4.0-dev+5379"
+    @test @compat(Union{}) == None
+    @test @compat(Union{Int,Float64}) == Union(Int,Float64)
+    @test @compat(:(Union{})) == :(Union())
+end


### PR DESCRIPTION
Skip applying the Void -> Nothing transformation for cases such as:

```julia
julia> using Compat

julia> @compat Dict(:Void => :Nothing)
Dict{Symbol,Symbol} with 1 entry:
  :Nothing => :Nothing
```

which is what broke the JLD/JLDArchives tests