### PR TITLE
Revert "Add doc_str and doc macros, to support Base.Docs/Docile syntax."

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@inline` and `@noinline` have been added. On 0.3, these are "no-ops," meaning they don't actually do anything.
 
-* `@doc`, `@doc_str` and `@doc_mstr` have been added. On 0.3 if Docile is available it will use its definitions, else these are no-ops.
-
 ## Other changes
 
 * `Dict(ks, vs)` is now `Dict(zip(ks, vs))` [#8521](https://github.com/JuliaLang/julia/pull/8521)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -45,17 +45,6 @@ if VERSION < v"0.4.0-dev+412"
     eval(Base, :(const IPAddr = IpAddr))
 end
 
-if VERSION < v"0.4.0-dev+1501"
-    try
-        import Docile: @doc_str, @doc_mstr, @doc
-    catch
-        macro doc_str(x) x end
-        macro doc_mstr(x) x end
-        macro doc(ex) esc(ex.args[end]) end
-    end
-    export @doc_str, @doc_mstr, @doc
-end
-
 if VERSION < v"0.4.0-dev+2197"
     Base.IPv4(ipstr::AbstractString) = Base.parseipv4(ipstr)
     Base.IPv6(ipstr::AbstractString) = Base.parseipv6(ipstr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,21 +62,6 @@ ns = length(d.slots)
 @test @compat rsplit("a,b,,c", ',', keep=false) == ["a", "b", "c"]
 @test @compat rsplit("a,b,,c", ',', keep=true) == ["a", "b", "", "c"]
 
-# We test that the following doc-syntax does not raise in 0.3.
-# and that the methods are still defined.
-doc"foo $latex$"
-function foo_doc() end
-
-doc"""multi-line"""
-function foo_mdoc() end
-
-@doc "docstring" ->
-function foo_macrodoc() end
-
-@test foo_doc() == nothing
-@test foo_mdoc() == nothing
-@test foo_macrodoc() == nothing
-
 if VERSION < v"0.4.0-dev+1387"
     @test isdefined(Main, :AbstractString)
 end


### PR DESCRIPTION
This reverts commit 0c57f272f6e124ae6af211bc9f24b0023694f893.

See https://github.com/JuliaLang/Compat.jl/pull/126#issuecomment-141771087 and mailing list post https://groups.google.com/forum/#!topic/julia-users/rsM4hxdkAxg.

I doubt that any packages on 0.3 are relying on Compat providing `@doc` rather than directly importing it from Docile, so I don't think reverting this should be a problem.

cc @hayd