### PR TITLE
brackets around union in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat Void` - `Nothing` on 0.3 (`Ptr{Void}` is not changed).
 
-* `@compat Union{args...}` - `Union(args...)` on 0.3. [#11432](https://github.com/JuliaLang/julia/pull/11432)
+* `@compat(Union{args...})` - `Union(args...)` on 0.3. [#11432](https://github.com/JuliaLang/julia/pull/11432)
 
 ## Type Aliases
 


### PR DESCRIPTION
Recommend using
```jl
@compat(Union{args...})
```
instead of
```jl
(@compat Union{args...})
```
Using the latter in this context:
```jl
typealias MeasureOrNumber (@compat Union{Measure, Number})
```
yields the following error on 0.4 because of the Tuple-looking brackets:
```jl
ERROR: LoadError: LoadError: TypeError: Tuple: in parameter, expected Type{T}, got Tuple{Union}
```