### PR TITLE
Add a default value for the input to __precompile__

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Timer(timeout::Real, repeat::Real=0.0)` and `Timer(cb::Function, timeout::Real, repeat::Real=0.0)` allow julia 0.4-style Timers to be constructed and used.
 
-* `__precompile(iscompiled::Bool)__` and `include_dependency(path::AbstractString)` allow
+* `__precompile__(iscompiled::Bool)` and `include_dependency(path::AbstractString)` allow
   Julia 0.4 precompilation information to be provided (with no effect in earlier versions).
   (However, to enable precompiling in 0.4, it is better to explicitly put `VERSION >= v"0.4.0-dev+6521" && __precompile__()` before your `module` statement, so that Julia knows to precompile before anything in your module is evaluated.)
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -633,7 +633,7 @@ if VERSION < v"0.4.0-dev+5697"
 end
 
 if VERSION < v"0.4.0-dev+6521"
-    __precompile__(::Bool) = nothing
+    __precompile__(isprecompilable::Bool = true) = nothing
     export __precompile__
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -448,6 +448,7 @@ Compat.@irrational mathconst_one 1.0 big(1.)
 @test base64encode("hello world") == "aGVsbG8gd29ybGQ="
 
 @test nothing === __precompile__(false) # tests should never be precompiled
+@test nothing === __precompile__()
 @test nothing === include_dependency("foo")
 
 @test real(Int) == real(Complex{Int}) == Int


### PR DESCRIPTION
I think this is causing https://groups.google.com/forum/#!topic/julia-users/0abTv_UK4UY