### PR TITLE
HEAD independent version script

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## Developer tips
 
-If you're adding additional compatibility code to this package, the [`bin/version.sh` script is useful for extracting the version number from a git commit SHA. For example, from the git repository of `julia`, run something like this:
+If you're adding additional compatibility code to this package, the [`bin/version.sh`](https://github.com/JuliaLang/Compat.jl/blob/master/bin/version.sh) script is useful for extracting the version number from a git commit SHA. For example, from the git repository of `julia`, run something like this:
 
 ```sh
 bash $ /path/to/Compat/bin/version.sh a378b60fe483130d0d30206deb8ba662e93944da
 0.5.0-dev+2023
 ```
 
-This prints a number `XXXX`, and you can then test whether Julia
-is at least this version by `VERSION >= v"0.Y.0-dev+XXXX"` (assuming
-it is a commit from the 0.Y development cycle).
+This prints a version number corresponding to the specified commit of the form
+`X.Y.Z-aaa+NNNN`, and you can then test whether Julia
+is at least this version by `VERSION >= v"X.Y.Z-aaa+NNNN"`.

--- a/bin/version.sh
+++ b/bin/version.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-last_tag=$(git describe --tags --abbrev=0)
-ver=$(cat VERSION)
-nb=$(git rev-list $1 ^$last_tag | wc -l | sed -e 's/[^[:digit:]]//g')
+
+# Need to be run from a julia repo clone
+# First argument (Optional) is a ref to the commit
+
+gitref=${1:-HEAD}
+
+last_tag=$(git describe --tags --abbrev=0 "$gitref")
+ver=$(git show "$gitref:VERSION")
+nb=$(git rev-list --count "$gitref" "^$last_tag")
 echo "$ver+$nb"


### PR DESCRIPTION
A slightly better way to fix https://github.com/JuliaLang/Compat.jl/issues/151.

Do not rely on the current checkout version and consistently query version info for the commit specified (default to HEAD). The only requirement now is a clone of the julia repo with up-to-date commit and tag info (i.e. it needs to have the commit you specify and the latest tag before the commit).

Before,
```
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh      
0.5.0-dev+0
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh release-0.4  
0.5.0-dev+572
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh HEAD~      
0.5.0-dev+2980
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh 86cd5ea3c61426ebddd1d3809ffa869d6726fb30
0.5.0-dev+2048
```

After,
```
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh
0.5.0-dev+2983
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh release-0.4
0.4.4-pre+35
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh HEAD~        
0.5.0-dev+2980
yyc2:~/projects/julia/master
yuyichao% ~/projects/contrib/Compat.jl/bin/version.sh 86cd5ea3c61426ebddd1d3809ffa869d6726fb30
0.5.0-dev+2048
```
