### PR TITLE
Add @functorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@inline` and `@noinline` have been added. On 0.3, these are "no-ops," meaning they don't actually do anything.
 
+* `@functorize` (not present in any Julia version) takes a function (or operator) and turns it into a functor object if one is available in the used Julia version. E.g. something like `mapreduce(Base.AbsFun(), Base.MulFun(), x)` can now be written as `mapreduce(@functorize(abs), @functorize(*), x)` to work accross different Julia versions.
+
 ## Other changes
 
 * `Dict(ks, vs)` is now `Dict(zip(ks, vs))` [#8521](https://github.com/JuliaLang/julia/pull/8521)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -980,4 +980,79 @@ if !isdefined(Base, :istextmime)
     istextmime(m::@compat(Union{MIME,AbstractString})) = istext(m)
 end
 
+export @functorize
+macro functorize(f)
+    if VERSION >= v"0.5.0-dev+3701"
+        f === :scalarmax       ? :(Base.scalarmax) :
+        f === :scalarmin       ? :(Base.scalarmin) :
+        f
+    else
+        f = f === :identity        ? :(Base.IdFun()) :
+            f === :abs             ? :(Base.AbsFun()) :
+            f === :abs2            ? :(Base.Abs2Fun()) :
+            f === :exp             ? :(Base.ExpFun()) :
+            f === :log             ? :(Base.LogFun()) :
+            f === :&               ? :(Base.AndFun()) :
+            f === :|               ? :(Base.OrFun()) :
+            f === :+               ? :(Base.AddFun()) :
+            f === :*               ? :(Base.MulFun()) :
+            f === :scalarmax       ? :(Base.MaxFun()) :
+            f === :scalarmin       ? :(Base.MinFun()) :
+            f
+        if VERSION >= v"0.4.0-dev+4902"
+            f = f === :<           ? :(Base.LessFun()) :
+                f === :>           ? :(Base.MoreFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-dev+4902"
+            f = f === :conj        ? :(Base.ConjFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-dev+6254"
+            f = f === :-           ? :(Base.SubFun()) :
+                f === :^           ? :(Base.PowFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-dev+6256"
+            f = f === :/           ? :(Base.RDivFun()) :
+                f === :\           ? :(Base.LDivFun()) :
+                f === :div         ? :(Base.IDivFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-dev+6353"
+            f = f === :$           ? :(Base.XorFun()) :
+                f === :.+          ? :(Base.DotAddFun()) :
+                f === :.-          ? :(Base.DotSubFun()) :
+                f === :.*          ? :(Base.DotMulFun()) :
+                f === :mod         ? :(Base.ModFun()) :
+                f === :rem         ? :(Base.RemFun()) :
+                # DotRemFun is defined, but ::call(::DotRemFun, ...) is not until later
+                #f === :.%          ? :(Base.DotRemFun()) :
+                f === :.<<         ? :(Base.DotLSFun()) :
+                f === :.>>         ? :(Base.DotRSFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-dev+6359"
+            f = f === :./          ? :(Base.DotRDivFun()) :
+                f
+        end
+        if VERSION >= v"0.4.0-rc1+59"
+            f = f === :max         ? :(Base.ElementwiseMaxFun()) :
+                f === :min         ? :(Base.ElementwiseMinFun()) :
+                f
+        end
+        if VERSION >= v"0.5.0-dev+741"
+            f = f === :complex     ? :(Base.SparseArrays.ComplexFun()) :
+                f === :dot         ? :(Base.SparseArrays.DotFun()) :
+                f
+        end
+        if VERSION >= v"0.5.0-dev+1472"
+            f = f === symbol(".÷") ? :(Base.DotIDivFun()) :
+                f === :.%          ? :(Base.DotRemFun()) :
+                f
+        end
+        f
+    end
+end
+
 end # module

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -985,6 +985,7 @@ macro functorize(f)
     if VERSION >= v"0.5.0-dev+3701"
         f === :scalarmax       ? :(Base.scalarmax) :
         f === :scalarmin       ? :(Base.scalarmin) :
+        f === :centralizedabs2fun ? :(typeof(Base.centralizedabs2fun(0)).name.primary) :
         f
     else
         f = f === :identity        ? :(Base.IdFun()) :
@@ -998,6 +999,7 @@ macro functorize(f)
             f === :*               ? :(Base.MulFun()) :
             f === :scalarmax       ? :(Base.MaxFun()) :
             f === :scalarmin       ? :(Base.MinFun()) :
+            f === :centralizedabs2fun ? :(Base.CentralizedAbs2Fun) :
             f
         if VERSION >= v"0.4.0-dev+4902"
             f = f === :<           ? :(Base.LessFun()) :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1086,3 +1086,8 @@ end
 let a = rand(1:10, 10)
     @test mapreduce(identity, dot, a) == mapreduce(identity, @functorize(dot), a)
 end
+@test isa(@functorize(centralizedabs2fun)(1), @functorize(centralizedabs2fun))
+@test isa(@functorize(centralizedabs2fun)(1.0), @functorize(centralizedabs2fun))
+let a = rand(1:10, 10)
+    @eval @test mapreduce(x -> abs2(x - 1), +, $(a)) == mapreduce(@functorize(centralizedabs2fun)(1), +, $(a))
+end


### PR DESCRIPTION
The new macro `@functorize(f)` turns a function `f` into a functor object if
there is one in Base corresponding to `f`. E.g. `@functorize(+)` yields
`Base.AddFun()`; `@functorize(<)` yields `<` in Julia 0.3, but `Base.LessFun()`
in 0.4.

While at present this would more naturally be achieved by providing `LessFun` etc. in Compat, this PR is in anticipation of JuliaLang/julia#15804, which will deprecate all functors.

Note that the version check in this PR can only be finalized once JuliaLang/julia#15804 has been merged.