### PR TITLE
Add support for RemoteChannel/RemoteRef

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -528,6 +528,9 @@ function _compat(ex::Symbol)
     if VERSION < v"0.4.0-dev+768" && ex === :Void
         return :Nothing
     end
+    if VERSION < v"0.5.0-dev+1343" && (ex == :Future || ex == :RemoteChannel)
+        return :RemoteRef
+    end
     return ex
 end
 _compat(ex) = ex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -999,4 +999,8 @@ rm(dirwalk, recursive=true)
 r = remotecall(sin, 1, pi/3)
 @compat foo(r::Future) = 7
 @test foo(r) == 7
-@compat rc = RemoteChannel{Channel{Any}}(1,2,3)
+if VERSION < v"0.4.0"
+    @compat rc = RemoteChannel(1,2,3)
+else
+    @compat rc = RemoteChannel{Channel{Any}}(1,2,3)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -994,3 +994,9 @@ cd(dirwalk) do
 
 end
 rm(dirwalk, recursive=true)
+
+# RemoteChannel/Future
+r = remotecall(sin, 1, pi/3)
+@compat foo(r::Future) = 7
+@test foo(r) == 7
+@compat rc = RemoteChannel{Channel{Any}}(1,2,3)


### PR DESCRIPTION
See also https://github.com/JuliaLang/julia/pull/15953 for further discussion.

CC @amitmurthy. This doesn't obviate the need for trying to come up with a more complete deprecation strategy, but at least with this, adding `@compat` will allow support for both 0.4 and 0.5.
