### PR TITLE
RFC: Add compat for at-threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `cov` and `cor` don't allow keyword arguments anymore. Loading Compat defines compatibility methods for the new API. [#13465](https://github.com/JuliaLang/julia/pull/13465)
 
+* On versions of Julia that do not contain a Base.Threads module, Compat defines a Threads module containing a no-op `@threads` macro.
+
 ## New types
 
 * [`Nullable` types](http://julia.readthedocs.org/en/latest/manual/types/?highlight=nullable#nullable-types-representing-missing-values) and their associated operations.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1057,7 +1057,7 @@ macro functorize(f)
     end
 end
 
-if !isdefined(Base, :threads)
+if !isdefined(Base, :Threads)
     @eval module Threads
         macro threads(expr)
             return esc(expr)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1057,4 +1057,14 @@ macro functorize(f)
     end
 end
 
+if !isdefined(Base, :threads)
+    @eval module Threads
+        macro threads(expr)
+            return esc(expr)
+        end
+        export @threads
+    end
+    export Threads
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1093,11 +1093,7 @@ let a = rand(1:10, 10)
 end
 
 # Threads.@threads
-if isdefined(Base, :Threads)
-    using Base.Threads
-else
-    using Compat.Threads
-end
+using Compat.Threads
 @threads for i=1:10
     @test true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1091,3 +1091,13 @@ end
 let a = rand(1:10, 10)
     @eval @test mapreduce(x -> abs2(x - 1), +, $(a)) == mapreduce(@functorize(centralizedabs2fun)(1), +, $(a))
 end
+
+# Threads.@threads
+if isdefined(Base, :Threads)
+    using Base.Threads
+else
+    using Compat.Threads
+end
+@threads for i=1:10
+    @test true
+end


### PR DESCRIPTION
no op macro for older versions of Julia that don't have a Threads module in Base