### PR TITLE
add Symbol constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `istext` is now `istextmime` [#15708](https://github.com/JuliaLang/julia/pull/15708)
 
-* `symbol` is now `Symbol` [#16154](https://github.com/JuliaLang/julia/pull/16154)
+* `symbol` is now `Symbol` [#16154](https://github.com/JuliaLang/julia/pull/16154); use `@compat Symbol(...)` if you need Julia 0.3 compatibility.
 
 ## New macros
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `istext` is now `istextmime` [#15708](https://github.com/JuliaLang/julia/pull/15708)
 
+* `symbol` is now `Symbol` [#16154](https://github.com/JuliaLang/julia/pull/16154)
+
 ## New macros
 
 * `@inline` and `@noinline` have been added. On 0.3, these are "no-ops," meaning they don't actually do anything.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1086,7 +1086,7 @@ if !isdefined(Base, :Threads)
 end
 
 if v"0.4.0-dev+3732" ≤ VERSION < v"0.5.0-dev+3831"
-    Symbol(args...) = symbol(args...)
+    Base.Symbol(args...) = symbol(args...)
 end
 
 end # module

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -418,7 +418,8 @@ if VERSION < v"0.4.0-dev+3732"
                    (:Complex64,:complex64),
                    (:Complex128,:complex128),
                    (:Char,:char),
-                   (:Bool,:bool)]
+                   (:Bool,:bool),
+                   (:Symbol,:symbol)]
         calltypes[k] = v
     end
 end
@@ -457,6 +458,8 @@ function _compat(ex::Expr)
             T = ex.args[1]
             if T in (:Complex32, :Complex64, :Complex128)
                 ex = Expr(:call, calltypes[T], ex.args[2:end]...)
+            elseif T == :Symbol
+                ex = Expr(:call, calltypes[T], Expr(:call, :string, ex.args[2:end]...))
             else
                 ex = Expr(:(::), Expr(:call, :convert, T, ex.args[2:end]...), T)
             end
@@ -498,7 +501,7 @@ function _compat(ex::Expr)
         end
     elseif ex.head === :macrocall
         f = ex.args[1]
-        if f === Symbol("@generated") && VERSION < v"0.4.0-dev+4387"
+        if VERSION < v"0.4.0-dev+4387" && f === symbol("@generated")
             f = ex.args[2]
             if isexpr(f, :function)
                 ex = Expr(:stagedfunction, f.args...)
@@ -710,7 +713,7 @@ end
 
 if VERSION < v"0.4.0-dev+5688"
     typealias Irrational MathConst
-    @eval const $(Symbol("@irrational")) = getfield(Base, Symbol("@math_const"))
+    @eval const $(symbol("@irrational")) = getfield(Base, symbol("@math_const"))
     export Irrational
 else
     import Base.@irrational
@@ -1082,9 +1085,7 @@ if !isdefined(Base, :Threads)
     export Threads
 end
 
-if VERSION < v"0.4.0-dev+2678"
-    Symbol(args...) = symbol(string(args...))
-elseif VERSION < v"0.5.0-dev+3831"
+if v"0.4.0-dev+3732" ≤ VERSION < v"0.5.0-dev+3831"
     Symbol(args...) = symbol(args...)
 end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1081,7 +1081,9 @@ if !isdefined(Base, :Threads)
     end
     export Threads
 
-if VERSION < v"0.5.0-dev+3831"
+if VERSION < v"0.4.0-dev+2678"
+    Symbol(args...) = symbol(string(args...))
+elseif VERSION < v"0.5.0-dev+3831"
     Symbol(args...) = symbol(args...)
 end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -422,6 +422,8 @@ if VERSION < v"0.4.0-dev+3732"
                    (:Symbol,:symbol)]
         calltypes[k] = v
     end
+elseif VERSION < v"0.5.0-dev+3831"
+    Base.Symbol(args...) = symbol(args...)
 end
 
 if VERSION < v"0.5.0-dev+2396"
@@ -1083,10 +1085,6 @@ if !isdefined(Base, :Threads)
         export @threads
     end
     export Threads
-end
-
-if v"0.4.0-dev+3732" ≤ VERSION < v"0.5.0-dev+3831"
-    Base.Symbol(args...) = symbol(args...)
 end
 
 end # module

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -498,7 +498,7 @@ function _compat(ex::Expr)
         end
     elseif ex.head === :macrocall
         f = ex.args[1]
-        if f === symbol("@generated") && VERSION < v"0.4.0-dev+4387"
+        if f === Symbol("@generated") && VERSION < v"0.4.0-dev+4387"
             f = ex.args[2]
             if isexpr(f, :function)
                 ex = Expr(:stagedfunction, f.args...)
@@ -710,7 +710,7 @@ end
 
 if VERSION < v"0.4.0-dev+5688"
     typealias Irrational MathConst
-    @eval const $(symbol("@irrational")) = getfield(Base, symbol("@math_const"))
+    @eval const $(Symbol("@irrational")) = getfield(Base, Symbol("@math_const"))
     export Irrational
 else
     import Base.@irrational
@@ -1064,7 +1064,7 @@ macro functorize(f)
                 f
         end
         if VERSION >= v"0.5.0-dev+1472"
-            f = f === symbol(".÷") ? :(Base.DotIDivFun()) :
+            f = f === Symbol(".÷") ? :(Base.DotIDivFun()) :
                 f === :.%          ? :(Base.DotRemFun()) :
                 f
         end
@@ -1080,6 +1080,9 @@ if !isdefined(Base, :Threads)
         export @threads
     end
     export Threads
+
+if VERSION < v"0.5.0-dev+3831"
+    Symbol(args...) = symbol(args...)
 end
 
 end # module

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1080,6 +1080,7 @@ if !isdefined(Base, :Threads)
         export @threads
     end
     export Threads
+end
 
 if VERSION < v"0.4.0-dev+2678"
     Symbol(args...) = symbol(string(args...))

--- a/src/ngenerate.jl
+++ b/src/ngenerate.jl
@@ -3,7 +3,7 @@ module CompatCartesian
 export @ngenerate, @nsplat
 
 macro ngenerate(itersym, returntypeexpr, funcexpr)
-    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == symbol("@inline")
+    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == Symbol("@inline")
         funcexpr = Base._inline(funcexpr.args[2])
     end
     isfuncexpr(funcexpr) || error("Requires a function expression")
@@ -32,7 +32,7 @@ macro nsplat(itersym, args...)
     else
         error("Wrong number of arguments")
     end
-    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == symbol("@inline")
+    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == Symbol("@inline")
         funcexpr = Base._inline(funcexpr.args[2])
     end
     isfuncexpr(funcexpr) || error("Second argument must be a function expression")
@@ -45,14 +45,14 @@ macro nsplat(itersym, args...)
 end
 
 function _nsplat(prototype, body, varname, T, itersym)
-    varsym = symbol(varname)
+    varsym = Symbol(varname)
     prototype.args[end] = Expr(:..., Expr(:(::), varsym, T)) # :($varsym::$T...)
     varquot = Expr(:quote, varsym)
     bodyquot = Expr(:quote, body)
     newbody = quote
         $itersym = length($varsym)
         quote
-            Base.Cartesian.@nexprs $($itersym) (d->$($(Expr(:quote, symbol(varsym, "_d")))) = $($varquot)[d])
+            Base.Cartesian.@nexprs $($itersym) (d->$($(Expr(:quote, Symbol(varsym, "_d")))) = $($varquot)[d])
             $(Compat.CompatCartesian.resolvesplats!($bodyquot, $varquot, $itersym))
         end
     end
@@ -87,7 +87,7 @@ function resolvesplats!(ex::Expr, varname, N::Int)
             resolvesplats!(ex.args[i], varname, N)
         end
         a = ex.args[end]
-        if isa(a, Expr) && a.head == :... && a.args[1] == symbol(varname)
+        if isa(a, Expr) && a.head == :... && a.args[1] == Symbol(varname)
             ex.args[end] = :($varname[1]) # Expr(:ref, varname, 1)
             for i = 2:N
                 push!(ex.args, :($varname[$i])) # Expr(:ref, varname, i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1103,5 +1103,14 @@ using Compat.Threads
     @test true
 end
 
-@test Symbol("foo") === :foo
-@test Symbol("foo", "bar") === :foobar
+if VERSION < v"0.4.0-dev+3732"
+    @test @compat(Symbol("foo")) === :foo
+    @test @compat(Symbol("foo", "bar")) === :foobar
+    @test @compat(Symbol("a_", 2)) === :a_2
+    @test @compat(Symbol('c')) === :c
+else
+    @test Symbol("foo") === :foo
+    @test Symbol("foo", "bar") === :foobar
+    @test Symbol("a_", 2) === :a_2
+    @test Symbol('c') === :c
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1103,12 +1103,12 @@ using Compat.Threads
     @test true
 end
 
-if VERSION < v"0.4.0-dev+3732"
-    @test @compat(Symbol("foo")) === :foo
-    @test @compat(Symbol("foo", "bar")) === :foobar
-    @test @compat(Symbol("a_", 2)) === :a_2
-    @test @compat(Symbol('c')) === :c
-else
+@test @compat(Symbol("foo")) === :foo
+@test @compat(Symbol("foo", "bar")) === :foobar
+@test @compat(Symbol("a_", 2)) === :a_2
+@test @compat(Symbol('c')) === :c
+
+if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("foo") === :foo
     @test Symbol("foo", "bar") === :foobar
     @test Symbol("a_", 2) === :a_2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1107,10 +1107,12 @@ end
 @test @compat(Symbol("foo", "bar")) === :foobar
 @test @compat(Symbol("a_", 2)) === :a_2
 @test @compat(Symbol('c')) === :c
+@test @compat(Symbol(1)) === @compat(Symbol("1"))
 
 if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("foo") === :foo
     @test Symbol("foo", "bar") === :foobar
     @test Symbol("a_", 2) === :a_2
     @test Symbol('c') === :c
+    @test Symbol(1) === Symbol("1")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1102,3 +1102,6 @@ using Compat.Threads
 @threads for i=1:10
     @test true
 end
+
+@test Symbol("foo") === :foo
+@test Symbol("foo", "bar") === :foobar


### PR DESCRIPTION
This defines `Symbol(args...)` constructor because `symbol(args...)` is deprecated in https://github.com/JuliaLang/julia/commit/5c4058e115dec44b5ed470b054fc41053c17aadf.

CC: @hayd 