### PR TITLE
@compat for f.(args...) and foo.:bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ wherever you want to use syntax that differs in the latest Julia
 
 Currently, the `@compat` macro supports the following syntaxes:
 
+* `@compat foo.:bar` - `foo.(:bar)` in 0.4 ([#15032]).
+
+* `@compat f.(args...)` - `broadcast(f, args...)` in 0.4 ([#15032]).
+
 * `@compat (a::B{T}){T}(c) = d` - the Julia 0.5-style call overload.
 
 * `@compat Dict(foo => bar, baz => qux)` - type-inferred `Dict` construction. (Also works for `DataStructures.OrderedDict`)
@@ -204,3 +208,5 @@ bash $ /path/to/Compat/bin/version.sh a378b60fe483130d0d30206deb8ba662e93944da
 This prints a version number corresponding to the specified commit of the form
 `X.Y.Z-aaa+NNNN`, and you can then test whether Julia
 is at least this version by `VERSION >= v"X.Y.Z-aaa+NNNN"`.
+
+[#15032]: https://github.com/JuliaLang/julia/issues/15032

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -542,18 +542,18 @@ function _compat(ex::Expr)
             callexpr.args[3] = obj
         end
     elseif VERSION < v"0.5.0-dev+4002" && ex.head == :. && length(ex.args) == 2 # 15032
-        if isexpr(ex.args[2], :quote) && typeof(ex.args[2].args[1]) == QuoteNode
+        if isexpr(ex.args[2], :quote) && isa(ex.args[2].args[1], QuoteNode)
             # foo.:bar -> foo.(:bar) in older Julia
             return Expr(ex.head, _compat(ex.args[1]), ex.args[2].args[1])
         elseif isexpr(ex.args[2], :quote) && isexpr(ex.args[2].args[1], :quote) &&
-               typeof(ex.args[2].args[1].args[1]) == Symbol
+               isa(ex.args[2].args[1].args[1], Symbol)
             # foo.:bar -> foo.(:bar) in older Julia
             return Expr(ex.head, _compat(ex.args[1]), QuoteNode(ex.args[2].args[1].args[1]))
         elseif isexpr(ex.args[2], :tuple)
             # f.(arg1, arg2...) -> broadcast(f, arg1, arg2...)
             return Expr(:call, :broadcast, _compat(ex.args[1]), map(_compat, ex.args[2].args)...)
-        elseif typeof(ex.args[2]) != QuoteNode &&
-               !(isexpr(ex.args[2], :quote) && typeof(ex.args[2].args[1]) == Symbol)
+        elseif !isa(ex.args[2], QuoteNode) &&
+               !(isexpr(ex.args[2], :quote) && isa(ex.args[2].args[1], Symbol))
             # f.(arg) -> broadcast(f, arg)
             return Expr(:call, :broadcast, _compat(ex.args[1]), _compat(ex.args[2]))
         end

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -541,6 +541,22 @@ function _compat(ex::Expr)
             callexpr.args[2] = params
             callexpr.args[3] = obj
         end
+    elseif VERSION < v"0.5.0-dev+4002" && ex.head == :. && length(ex.args) == 2 # 15032
+        if isexpr(ex.args[2], :quote) && typeof(ex.args[2].args[1]) == QuoteNode
+            # foo.:bar -> foo.(:bar) in older Julia
+            return Expr(ex.head, _compat(ex.args[1]), ex.args[2].args[1])
+        elseif isexpr(ex.args[2], :quote) && isexpr(ex.args[2].args[1], :quote) &&
+               typeof(ex.args[2].args[1].args[1]) == Symbol
+            # foo.:bar -> foo.(:bar) in older Julia
+            return Expr(ex.head, _compat(ex.args[1]), QuoteNode(ex.args[2].args[1].args[1]))
+        elseif isexpr(ex.args[2], :tuple)
+            # f.(arg1, arg2...) -> broadcast(f, arg1, arg2...)
+            return Expr(:call, :broadcast, _compat(ex.args[1]), map(_compat, ex.args[2].args)...)
+        elseif typeof(ex.args[2]) != QuoteNode &&
+               !(isexpr(ex.args[2], :quote) && typeof(ex.args[2].args[1]) == Symbol)
+            # f.(arg) -> broadcast(f, arg)
+            return Expr(:call, :broadcast, _compat(ex.args[1]), _compat(ex.args[2]))
+        end
     end
     return Expr(ex.head, map(_compat, ex.args)...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1109,6 +1109,12 @@ end
 @test @compat(Symbol('c')) === :c
 @test @compat(Symbol(1)) === @compat(Symbol("1"))
 
+@test @compat(Base.:+) == +
+let x = rand(3), y = rand(3)
+    @test @compat(sin.(cos.(x))) == map(x -> sin(cos(x)), x)
+    @test @compat(atan2.(sin.(y),x)) == broadcast(atan2,map(sin,y),x)
+end
+
 if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("foo") === :foo
     @test Symbol("foo", "bar") === :foobar


### PR DESCRIPTION
This adds compatibility for JuliaLang/julia#15032.