### PR TITLE
Add unexported alias for UTF8String and ASCIIString

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `String` has undergone multiple changes: in julia 0.3 it was an abstract type and then got renamed to `AbstractString`; later, `ASCIIString` and `UTF8String` got merged into a concrete type, `String`.
 
+    For packages that still need `ASCIIString` or `UTF8String` on julia 0.4 and
+    want to avoid the deprecation warning on julia 0.5,
+    use `Compat.ASCIIString` and `Compat.UTF8String` instead.
+    Note that `Compat.ASCIIString` does **not** guarantee `isascii` on julia 0.5.
+    Use `isascii` to check if the string is pure ASCII if needed.
+
 * `typealias AbstractString String` - `String` has been renamed to `AbstractString` [#8872](https://github.com/JuliaLang/julia/pull/8872)
 
 * `typealias AbstractFloat FloatingPoint` - `FloatingPoint` has been renamed to `AbstractFloat` [#12162](https://github.com/JuliaLang/julia/pull/12162)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -6,6 +6,9 @@ using Base.Meta
 
 if isdefined(Core, :String) && isdefined(Core, :AbstractString)
     typealias String Core.String
+    # Not exported in order to not break code on 0.5
+    typealias UTF8String Core.String
+    typealias ASCIIString Core.String
 else
     typealias String Base.ByteString
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,8 +393,8 @@ let s = "abcdef", u8 = "abcdef\uff", u16 = utf16(u8), u32 = utf32(u8),
     @test isvalid(u8)
     @test isvalid(u16)
     @test isvalid(u32)
-    @test isvalid(ASCIIString, s)
-    @test isvalid(UTF8String,  u8)
+    @test isvalid(Compat.ASCIIString, s)
+    @test isvalid(Compat.UTF8String,  u8)
     @test isvalid(UTF16String, u16)
     @test isvalid(UTF32String, u32)
 end
@@ -668,10 +668,10 @@ mktempdir() do dir
 
         for text in [
             old_text,
-            convert(UTF8String, Char['A' + i % 52 for i in 1:(div(SZ_UNBUFFERED_IO,2))]),
-            convert(UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO -1)]),
-            convert(UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO   )]),
-            convert(UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO +1)])
+            convert(Compat.UTF8String, Char['A' + i % 52 for i in 1:(div(SZ_UNBUFFERED_IO,2))]),
+            convert(Compat.UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO -1)]),
+            convert(Compat.UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO   )]),
+            convert(Compat.UTF8String, Char['A' + i % 52 for i in 1:(    SZ_UNBUFFERED_IO +1)])
         ]
 
             write(filename, text)
@@ -1053,7 +1053,7 @@ for (Fun, func) in [(:AndFun,              :&),
                     (:DotRDivFun,          :./),
                     (:LDivFun,             :\),
                     (:IDivFun,             :div),
-                    (:DotIDivFun,          symbol(".÷")),
+                    (:DotIDivFun,          @compat(Symbol(".÷"))),
                     (:ModFun,              :mod),
                     (:RemFun,              :rem),
                     (:DotRemFun,           :.%),
@@ -1127,3 +1127,5 @@ end
 foostring(::String) = 1
 @test foostring("hello") == 1
 @test foostring("λ") == 1
+@test isa("hello", Compat.ASCIIString)
+@test isa("λ", Compat.UTF8String)


### PR DESCRIPTION
To help package to upgrade without breaking API on julia 0.4.

As discussed in https://github.com/JuliaLang/Compat.jl/pull/197#discussion_r62842265

The name and the expected usage are picked using the follow reasoning,

1. Since this is a reverse `Compat` usage the usage should have `Compat` in it so it is easy to search and fix when 0.4 support is dropped from the package that uses this. The package can still `import` the symbol.
2. `Compat.*` is as easy to write as `Compat*`, might as well make it simpler (and reduce a few lines of code for 0.4)
3. The binding is not exported in order to not break packages on 0.5. Otherwise, a package that `using Compat` without importing explicitly will get a error when using `UTF8String` or `ASCIIString` on 0.5 instead of a deprecation.

Also fix a few warnings in the test.

@timholy @stevengj 
