### PR TITLE
Don't export String since it is already exported by Base

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -5,14 +5,12 @@ module Compat
 using Base.Meta
 
 if isdefined(Core, :String) && isdefined(Core, :AbstractString)
-    typealias String Core.String
     # Not exported in order to not break code on 0.5
     typealias UTF8String Core.String
     typealias ASCIIString Core.String
 else
     typealias String Base.ByteString
 end
-export String
 
 if VERSION < v"0.4.0-dev+2340"
     const base64encode = base64


### PR DESCRIPTION
otherwise `Pkg.test("MLBase")` for example will hit
`WARNING: both Compat and Base export "String"; uses of it in module MLBase must be qualified`
then fail with an `UndefVarError: String not defined`

ref https://github.com/JuliaLang/Compat.jl/pull/197#issuecomment-218547177