### PR TITLE
Backport @static macro (JuliaLang/julia#16219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## New macros
 
+* `@static` has been added [#16219](https://github.com/JuliaLang/julia/pull/16219).
+
 * `@inline` and `@noinline` have been added. On 0.3, these are "no-ops," meaning they don't actually do anything.
 
 * `@functorize` (not present in any Julia version) takes a function (or operator) and turns it into a functor object if one is available in the used Julia version. E.g. something like `mapreduce(Base.AbsFun(), Base.MulFun(), x)` can now be written as `mapreduce(@functorize(abs), @functorize(*), x)`, and `f(::Base.AbsFun())` as `f(::typeof(@functorize(abs)))`, to work across different Julia versions. `Func{1}` can be written as `supertype(typeof(@functorize(abs)))` (and so on for `Func{2}`), which will fall back to `Function` on Julia 0.5.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1118,4 +1118,24 @@ if !isdefined(Base, :unsafe_write)
     export unsafe_write
 end
 
+# JuliaLang/julia#16219
+if !isdefined(Base, @compat Symbol("@static"))
+     macro static(ex)
+        if isa(ex, Expr)
+            if ex.head === :if
+                cond = eval(current_module(), ex.args[1])
+                if cond
+                    return esc(ex.args[2])
+                elseif length(ex.args) == 3
+                    return esc(ex.args[3])
+                else
+                    return nothing
+                end
+            end
+        end
+        throw(ArgumentError("invalid @static macro"))
+    end
+    export @static
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1141,3 +1141,9 @@ let io = IOBuffer(), s = "hello"
     unsafe_write(io, pointer(s), length(s))
     @test takebuf_string(io) == s
 end
+
+@static if VERSION ≥ v"0.4"
+    @test VERSION ≥ v"0.4"
+else
+    @test VERSION < v"0.4"
+end


### PR DESCRIPTION
`@static` finally provides a canonical syntax for statically choosing code based off version. This is an exact copy of the `Base.@static` macro introduced in JuliaLang/julia#16219.

Closes #131.