### PR TITLE
fix #210: String(string)

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -34,7 +34,7 @@ else
         call(::Type{Base.ByteString},io::Base.AbstractIOBuffer) = bytestring(io::Base.AbstractIOBuffer)
         call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}) = bytestring(p::Union{Ptr{Int8},Ptr{UInt8}})
         call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) = bytestring(p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer)
-        call(::Type{Base.ByteString},s...) = bytestring(s::AbstractString...)
+        call(::Type{Base.ByteString},s::AbstractString) = bytestring(s)
     end
 end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -29,11 +29,11 @@ if isdefined(Core, :String) && isdefined(Core, :AbstractString)
 else
     typealias String Base.ByteString
     if VERSION >= v"0.4.0-dev+1246"
-        call(::Type{Base.ByteString},s::Cstring) = bytestring(s::Cstring)
-        call(::Type{Base.ByteString},v::Vector{UInt8}) = bytestring(v::Vector{UInt8})
-        call(::Type{Base.ByteString},io::Base.AbstractIOBuffer) = bytestring(io::Base.AbstractIOBuffer)
-        call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}) = bytestring(p::Union{Ptr{Int8},Ptr{UInt8}})
-        call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) = bytestring(p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer)
+        call(::Type{Base.ByteString},s::Cstring) = bytestring(s)
+        call(::Type{Base.ByteString},v::Vector{UInt8}) = bytestring(v)
+        call(::Type{Base.ByteString},io::Base.AbstractIOBuffer) = bytestring(io)
+        call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}) = bytestring(p)
+        call(::Type{Base.ByteString},p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) = bytestring(p, len)
         call(::Type{Base.ByteString},s::AbstractString) = bytestring(s)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1162,9 +1162,9 @@ let io = IOBuffer(), s = "hello"
     @test @compat String(pointer(s.data)) == s
     @test @compat String(pointer(s.data),length(s.data)) == s
     @test string(s, s, s) == "hellohellohello"
+    @test @compat(String(s)) == s
     @test String == @compat(Union{Compat.UTF8String,Compat.ASCIIString})
 end
-@test @compat(String("foo")) == "foo"
 
 @test Compat.repeat(1:2, inner=2) == [1, 1, 2, 2]
 @test Compat.repeat(1:2, outer=[2]) == [1, 2, 1, 2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1164,6 +1164,7 @@ let io = IOBuffer(), s = "hello"
     @test string(s, s, s) == "hellohellohello"
     @test String == @compat(Union{Compat.UTF8String,Compat.ASCIIString})
 end
+@test @compat(String("foo")) == "foo"
 
 @test Compat.repeat(1:2, inner=2) == [1, 1, 2, 2]
 @test Compat.repeat(1:2, outer=[2]) == [1, 2, 1, 2]


### PR DESCRIPTION
This fixes #210.

Note that it doesn't make sense to accept multiple string arguments to `String`, since in Julia 0.5 only `String(s::AbstractString)` exists.