### PR TITLE
Fix for removal of limit_output

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1183,3 +1183,6 @@ if VERSION < v"0.5.0-dev+4267"
 else
     @test Compat.KERNEL == Sys.KERNEL
 end
+
+io = IOBuffer()
+@test @compat(get(io, :limit, false)) == false


### PR DESCRIPTION
This is only needed to support multiple versions of julia-0.5, since `limit_output(io)` was introduced (+1936) and then removed (+4305).

For, e.g., BenchmarkTools, it seems important to be able to support a range of julia-0.5 versions.
