### PR TITLE
Change os dependent definitions to new syntax

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -128,86 +128,6 @@ elseif VERSION < v"0.4.0-dev+1039"
     Base.rem{T<:Integer}(n::Integer, ::Type{T}) = mod(n, T)
 end
 
-import Base: srand, rand, rand!
-if VERSION < v"0.4.0-dev+1373" # PR #8854
-    function make_seed()
-        try
-            @unix_only seed = open("/dev/urandom") do io
-                a = Array(UInt32, 4)
-                read!(io, a)
-                a
-            end
-            @windows_only seed = let a = zeros(UInt32, 2)
-                Base.dSFMT.win32_SystemFunction036!(a)
-                a
-            end
-            return seed
-        catch
-            println(STDERR, "Entropy pool not available to seed RNG; using ad-hoc entropy sources.")
-            seed = reinterpret(UInt64, time())
-            seed = hash(seed, convert(UInt64, getpid()))
-            try
-                seed = hash(seed, parse(UInt64, readall(`ifconfig` |> `sha1sum`)[1:40], 16))
-            end
-            return seed
-        end
-    end
-    if VERSION < v"0.4.0-dev+1352" # PR #8832
-        function srand(r::MersenneTwister, seed::Vector{UInt32})
-            r.seed = seed
-            Base.dSFMT.dsfmt_init_by_array(r.state, seed)
-            return r
-        end
-    else
-        function srand(r::MersenneTwister, seed::Vector{UInt32})
-            r.seed = seed
-            Base.dSFMT.dsfmt_init_by_array(r.state, seed)
-            r.idx = Base.dSFMT.dsfmt_get_min_array_size()
-            return r
-        end
-        rand(r::MersenneTwister, ::Type{UInt32})  = reinterpret(UInt64, Base.Random.rand_close1_open2(r)) % UInt32
-    end
-    srand(r::MersenneTwister, seed::Union(UInt32,Int32)) = srand(r, UInt32[seed])
-    srand(r::MersenneTwister, seed::Union(UInt64,Int64)) =
-        srand(r, UInt32[seed & 0xffffffff, seed >> 32])
-    srand(r::MersenneTwister) = srand(r, make_seed())
-
-    rand(r::MersenneTwister, ::Type{UInt8})   = rand(r, UInt32) % UInt8
-    rand(r::MersenneTwister, ::Type{UInt16})  = rand(r, UInt32) % UInt16
-    rand(r::MersenneTwister, ::Type{UInt32})  = reinterpret(UInt64, rand(r)) % UInt32
-    rand(r::MersenneTwister, ::Type{UInt64})  = convert(UInt64,rand(r, UInt32)) <<32 | rand(r, UInt32)
-    rand(r::MersenneTwister, ::Type{UInt128}) = convert(UInt128,rand(r, UInt64))<<64 | rand(r, UInt64)
-
-    for (T,Tu) in ((Int8,UInt8),(Int16,UInt16),(Int32,UInt32),(Int64,UInt64),(Int128,UInt128))
-        @eval rand(r::MersenneTwister, ::Type{$T}) = reinterpret($T, rand(r, $Tu))
-    end
-    rand(r::MersenneTwister, ::Type{Float64}) = rand(r)
-    rand(r::MersenneTwister, ::Type{Float64}) = rand(r)
-    rand{T<:Union(Float16,Float32)}(r::MersenneTwister, ::Type{T}) = convert(T, rand(r))
-    rand{T<:Real}(r::AbstractRNG, ::Type{Complex{T}}) = complex(rand(r, T), rand(r, T))
-    if VERSION < v"0.4.0-dev+1296" # commit 89befafa7deded0119d0186ef116e03ec91b9680
-        function rand!{T<:Number}(r::AbstractRNG, A::AbstractArray{T})
-            for i=1:length(A)
-                @inbounds A[i] = rand(r, T)
-            end
-            A
-        end
-    end
-    rand(r::AbstractRNG, T::Type, dims::Dims) = rand!(r, Array(T, dims))
-    rand(r::AbstractRNG, T::Type, d1::Int, dims::Int...) = rand!(r, Array(T, d1, dims...))
-    rand(r::MersenneTwister, ::Type{Bool}) = ((rand(r, UInt32) & 1) == 1)
-end
-
-if VERSION < v"0.4.0-dev+551" # PR #8320
-    srand() = srand(make_seed())
-end
-
-if VERSION < v"0.4.0-dev+1884"
-    randexp(rng::MersenneTwister) = Base.Random.randmtzig_exprnd(rng)
-    randexp() = Base.Random.randmtzig_exprnd()
-    export randexp
-end
-
 if VERSION < v"0.4.0-dev+2014"
     sizehint! = Base.sizehint
     export sizehint!
@@ -1240,6 +1160,89 @@ if VERSION < v"0.5.0-dev+4267"
     export is_apple, is_linux, is_bsd, is_unix, is_windows
 else
     const KERNEL = Sys.KERNEL
+end
+
+import Base: srand, rand, rand!
+if VERSION < v"0.4.0-dev+1373" # PR #8854
+    function make_seed()
+        try
+            @static if is_unix()
+                seed = open("/dev/urandom") do io
+                    a = Array(UInt32, 4)
+                    read!(io, a)
+                    a
+                end
+            elseif is_windows()
+                seed = let a = zeros(UInt32, 2)
+                    Base.dSFMT.win32_SystemFunction036!(a)
+                    a
+                end
+            end
+            return seed
+        catch
+            println(STDERR, "Entropy pool not available to seed RNG; using ad-hoc entropy sources.")
+            seed = reinterpret(UInt64, time())
+            seed = hash(seed, convert(UInt64, getpid()))
+            try
+                seed = hash(seed, parse(UInt64, readall(`ifconfig` |> `sha1sum`)[1:40], 16))
+            end
+            return seed
+        end
+    end
+    if VERSION < v"0.4.0-dev+1352" # PR #8832
+        function srand(r::MersenneTwister, seed::Vector{UInt32})
+            r.seed = seed
+            Base.dSFMT.dsfmt_init_by_array(r.state, seed)
+            return r
+        end
+    else
+        function srand(r::MersenneTwister, seed::Vector{UInt32})
+            r.seed = seed
+            Base.dSFMT.dsfmt_init_by_array(r.state, seed)
+            r.idx = Base.dSFMT.dsfmt_get_min_array_size()
+            return r
+        end
+        rand(r::MersenneTwister, ::Type{UInt32})  = reinterpret(UInt64, Base.Random.rand_close1_open2(r)) % UInt32
+    end
+    srand(r::MersenneTwister, seed::Union(UInt32,Int32)) = srand(r, UInt32[seed])
+    srand(r::MersenneTwister, seed::Union(UInt64,Int64)) =
+        srand(r, UInt32[seed & 0xffffffff, seed >> 32])
+    srand(r::MersenneTwister) = srand(r, make_seed())
+
+    rand(r::MersenneTwister, ::Type{UInt8})   = rand(r, UInt32) % UInt8
+    rand(r::MersenneTwister, ::Type{UInt16})  = rand(r, UInt32) % UInt16
+    rand(r::MersenneTwister, ::Type{UInt32})  = reinterpret(UInt64, rand(r)) % UInt32
+    rand(r::MersenneTwister, ::Type{UInt64})  = convert(UInt64,rand(r, UInt32)) <<32 | rand(r, UInt32)
+    rand(r::MersenneTwister, ::Type{UInt128}) = convert(UInt128,rand(r, UInt64))<<64 | rand(r, UInt64)
+
+    for (T,Tu) in ((Int8,UInt8),(Int16,UInt16),(Int32,UInt32),(Int64,UInt64),(Int128,UInt128))
+        @eval rand(r::MersenneTwister, ::Type{$T}) = reinterpret($T, rand(r, $Tu))
+    end
+    rand(r::MersenneTwister, ::Type{Float64}) = rand(r)
+    rand(r::MersenneTwister, ::Type{Float64}) = rand(r)
+    rand{T<:Union(Float16,Float32)}(r::MersenneTwister, ::Type{T}) = convert(T, rand(r))
+    rand{T<:Real}(r::AbstractRNG, ::Type{Complex{T}}) = complex(rand(r, T), rand(r, T))
+    if VERSION < v"0.4.0-dev+1296" # commit 89befafa7deded0119d0186ef116e03ec91b9680
+        function rand!{T<:Number}(r::AbstractRNG, A::AbstractArray{T})
+            for i=1:length(A)
+                @inbounds A[i] = rand(r, T)
+            end
+            A
+        end
+    end
+    rand(r::AbstractRNG, T::Type, dims::Dims) = rand!(r, Array(T, dims))
+    rand(r::AbstractRNG, T::Type, d1::Int, dims::Int...) = rand!(r, Array(T, d1, dims...))
+    rand(r::MersenneTwister, ::Type{Bool}) = ((rand(r, UInt32) & 1) == 1)
+end
+
+if VERSION < v"0.4.0-dev+551" # PR #8320
+    srand() = srand(make_seed())
+end
+
+if VERSION < v"0.4.0-dev+1884"
+    randexp(rng::MersenneTwister) = Base.Random.randmtzig_exprnd(rng)
+    randexp() = Base.Random.randmtzig_exprnd()
+    export randexp
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,7 @@ end
 @test CartesianTest.f(1,2,3,4) == (1,2,3,4)
 @test CartesianTest.f(1,2,3,4,5) == (1,2,3,4,5)
 
-extrapath = @windows? joinpath(JULIA_HOME,"..","Git","usr","bin")*";" : ""
+extrapath = is_windows() ? joinpath(JULIA_HOME,"..","Git","usr","bin")*";" : ""
 @compat withenv("PATH" => extrapath * ENV["PATH"]) do
     @test readstring(pipeline(`echo hello`, `sort`)) == "hello\n"
     @test success(pipeline(`true`, `true`))
@@ -406,11 +406,13 @@ let s = "abcdef", u8 = "abcdef\uff", u16 = utf16(u8), u32 = utf32(u8),
     @test isvalid(UTF32String, u32)
 end
 
-# chol
-let A = rand(2,2)
-    B = A'*A
-    U = @compat chol(B, Val{:U})
-    @test_approx_eq U'*U B
+if VERSION < v"0.5.0-dev+907"
+    # chol
+    let A = rand(2,2)
+        B = A'*A
+        U = @compat chol(B, Val{:U})
+        @test_approx_eq U'*U B
+    end
 end
 
 # @generated
@@ -920,7 +922,7 @@ cd(dirwalk) do
         touch(joinpath("sub_dir1", "file$i"))
     end
     touch(joinpath("sub_dir2", "file_dir2"))
-    has_symlinks = @unix? true : (isdefined(Base, :WINDOWS_VISTA_VER) && Base.windows_version() >= Base.WINDOWS_VISTA_VER)
+    has_symlinks = is_unix() ? true : (isdefined(Base, :WINDOWS_VISTA_VER) && Base.windows_version() >= Base.WINDOWS_VISTA_VER)
     follow_symlink_vec = has_symlinks ? [true, false] : [false]
     has_symlinks && symlink(abspath("sub_dir2"), joinpath("sub_dir1", "link"))
     for follow_symlinks in follow_symlink_vec


### PR DESCRIPTION
and move them to the end of the source file.

I've also added a condition for the `chol` test to avoid the warning on newer versions.