### PR TITLE
rewrite show as writemime for Julia v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat withenv(f, "a" => a, "b" => b...)` on 0.3.
 
+* `@compat import Base.show => Base.writemime` because writemime is deprecated in Julia 0.5 ([#16563]).
+
+* `@compat function show(args...) => writemime` because writemime is deprecated in Julia 0.5 ([#16563]).
+
 ## Type Aliases
 
 * `String` has undergone multiple changes: in Julia 0.3 it was an abstract type and then got renamed to `AbstractString` in 0.4; in 0.5, `ASCIIString` and `ByteString` were deprecated, and `UTF8String` was renamed to the (now concrete) type `String`.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -446,7 +446,7 @@ function _compat(ex::Expr)
             rewrite_pairs_to_tuples!(ex)
         elseif VERSION < v"0.4.0-dev+1246" && f == :String
             ex = Expr(:call, :bytestring, ex.args[2:end]...)
-        elseif VERSION < v"0.5.0-dev+4356" && length(ex.args) > 2 && ex.args[1] === :show
+        elseif VERSION < v"0.5.0-dev+4340" && length(ex.args) > 2 && ex.args[1] === :show
             ex = rewrite_show(ex)
         end
         if VERSION < v"0.5.0-dev+4305"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -188,7 +188,11 @@ if VERSION < v"0.5.0-dev+961"
 end
 
 function rewrite_show(ex)
-    return Expr(:call, :writemime, ex.args[2], ex.args[3], ex.args[4])
+    argtypes = ex.args[2:end]
+    if length(argtypes) == 2
+        insert!(argtypes, 2, Expr(:(::), :macrocall, MIME"text/plain"))
+    end
+    return Expr(:call, :writemime, argtypes...)
 end
 
 function rewrite_dict(ex)
@@ -442,7 +446,7 @@ function _compat(ex::Expr)
             rewrite_pairs_to_tuples!(ex)
         elseif VERSION < v"0.4.0-dev+1246" && f == :String
             ex = Expr(:call, :bytestring, ex.args[2:end]...)
-        elseif VERSION < v"0.5.0-dev+4356" && length(ex.args) == 4 && ex.args[1] === :show
+        elseif VERSION < v"0.5.0-dev+4356" && length(ex.args) > 2 && ex.args[1] === :show
             ex = rewrite_show(ex)
         end
         if VERSION < v"0.5.0-dev+4305"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -527,7 +527,7 @@ function _compat(ex::Expr)
             return Expr(:call, :broadcast, _compat(ex.args[1]), _compat(ex.args[2]))
         end
     elseif ex.head === :import
-        if length(ex.args) == 2 && ex.args[1] === :Base && ex.args[2] === :show
+        if VERSION < v"0.5.0-dev+4340" && length(ex.args) == 2 && ex.args[1] === :Base && ex.args[2] === :show
             ex.args[2] = :writemime
         end
     end

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -442,7 +442,7 @@ function _compat(ex::Expr)
             rewrite_pairs_to_tuples!(ex)
         elseif VERSION < v"0.4.0-dev+1246" && f == :String
             ex = Expr(:call, :bytestring, ex.args[2:end]...)
-        elseif length(ex.args) == 4 && ex.args[1] === :show
+        elseif VERSION < v"0.5.0-dev+4356" && length(ex.args) == 4 && ex.args[1] === :show
             ex = rewrite_show(ex)
         end
         if VERSION < v"0.5.0-dev+4305"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,21 @@
 using Compat
 import Compat.String
+@compat import Base.show
 using Base.Test
+
+type TestCustomShowType end
+@compat function show(io::IO, ::MIME"text/plain", ::TestCustomShowType)
+    print(io, "MyTestCustomShowType")
+end
+myio = IOBuffer()
+display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType())
+@test String(myio) == "MyTestCustomShowType"
+
+type TestCustomShowType2 end
+@compat show(io::IO, ::MIME"text/plain", ::TestCustomShowType2) = print(io, "MyTestCustomShowType2")
+myio = IOBuffer()
+display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType2())
+@test String(myio) == "MyTestCustomShowType2"
 
 v = 1
 @test_throws AssertionError @assert(v < 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,19 +12,19 @@ type TestCustomShowType end
 end
 myio = IOBuffer()
 display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType())
-@test String(myio) == "MyTestCustomShowType"
+@test @compat String(myio) == "MyTestCustomShowType"
 
 type TestCustomShowType2 end
 @compat show(io::IO, ::MIME"text/plain", ::TestCustomShowType2) = print(io, "MyTestCustomShowType2")
 myio = IOBuffer()
 display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType2())
-@test String(myio) == "MyTestCustomShowType2"
+@test @compat String(myio) == "MyTestCustomShowType2"
 
 type TestCustomShowType3 end
 @compat show(io::IO, ::TestCustomShowType3) = print(io, "2-Argument-show")
 myio = IOBuffer()
 display(TextDisplay(myio), TestCustomShowType3())
-@test String(myio) == "2-Argument-show"
+@test @compat String(myio) == "2-Argument-show"
 
 d = Dict{Int,Int}()
 d[1] = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ import Compat.String
 @compat import Base.show
 using Base.Test
 
+v = 1
+@test_throws AssertionError @assert(v < 1)
+
 type TestCustomShowType end
 @compat function show(io::IO, ::MIME"text/plain", ::TestCustomShowType)
     print(io, "MyTestCustomShowType")
@@ -17,8 +20,11 @@ myio = IOBuffer()
 display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType2())
 @test String(myio) == "MyTestCustomShowType2"
 
-v = 1
-@test_throws AssertionError @assert(v < 1)
+type TestCustomShowType3 end
+@compat show(io::IO, ::TestCustomShowType3) = print(io, "2-Argument-show")
+myio = IOBuffer()
+display(TextDisplay(myio), TestCustomShowType3())
+@test String(myio) == "2-Argument-show"
 
 d = Dict{Int,Int}()
 d[1] = 1


### PR DESCRIPTION
writemime was deprecated in JuliaLang/julia#16563 in julia commit
ae62bf0b813afbf32402874451e55d16de909bd4. This compatibility change
allows code that is written in the Julia v0.5 style to continue working
on Julia v0.4. I have not tested this on Julia v0.3.

The compat macro must be used on the import statement and the function
definition. For example:

```
@compat import Base.show
@compat show(io::IO, ::MIME"text/plain", ::TestCustomShowType) = print(io, "MyTestCustomShowType")
```