### PR TITLE
Rewrite 0.5 `@boundscheck` to a no-op in 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat import Base.show` and `@compat function show(args...)` for handling the deprecation of `writemime` in Julia 0.5 ([#16563]). See https://github.com/JuliaLang/Compat.jl/pull/219.
 
+* `@compat @boundscheck checkbounds(...)` rewrites to unconditionally call `checkbounds(...)` in 0.4.  The 0.4-style two-argument form of `@boundscheck` is left unchanged.
+
 ## Type Aliases
 
 * `String` has undergone multiple changes: in Julia 0.3 it was an abstract type and then got renamed to `AbstractString` in 0.4; in 0.5, `ASCIIString` and `ByteString` were deprecated, and `UTF8String` was renamed to the (now concrete) type `String`.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -492,6 +492,12 @@ function _compat(ex::Expr)
                 ex = Expr(:stagedfunction, f.args...)
             end
         end
+        if VERSION < v"0.5.0-dev+2129" && f === symbol("@boundscheck") && length(ex.args) == 2
+            # Handle 0.5 single argument @boundscheck syntax. (0.4 has a two
+            # arguments and a very diffferent meaning).  `nothing` is included
+            # so we have a consistent return type.
+            ex = :($(ex.args[2]); nothing)
+        end
     elseif VERSION < v"0.4.0-dev+5322" && ex.head === :(::) && isa(ex.args[end], Symbol)
         # Replace Base.Timer with Compat.Timer2 in type declarations
         if istopsymbol(ex.args[end], :Base, :Timer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1265,7 +1265,3 @@ end
     checked
 end
 @test do_boundscheck() == true
-if VERSION >= v"0.5.0-dev+2129"
-    do_boundscheck2() = (@inbounds c = do_boundscheck(); c)
-    @test do_boundscheck2() == false
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1256,3 +1256,16 @@ end
 let a = rand(10,10)
     @test view(a, :, 1) == a[:,1]
 end
+
+# Single argument 0.5-style `@boundscheck`.
+# A bit ugly since `@boundscheck` returns `nothing`.
+bounds_checked = false
+@inline checkbounds() = (global bounds_checked = true)
+bounds_checked = false
+@compat @boundscheck checkbounds()
+@test bounds_checked
+if VERSION >= v"0.5.0-dev+2129"
+    bounds_checked = false
+    @compat @inbounds @boundscheck checkbounds()
+    @test !bounds_checked
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1257,15 +1257,15 @@ let a = rand(10,10)
     @test view(a, :, 1) == a[:,1]
 end
 
-# Single argument 0.5-style `@boundscheck`.
-# A bit ugly since `@boundscheck` returns `nothing`.
-bounds_checked = false
-@inline checkbounds() = (global bounds_checked = true)
-bounds_checked = false
-@compat @boundscheck checkbounds()
-@test bounds_checked
+# 0.5 style single argument `@boundscheck`
+@inline function do_boundscheck()
+    # A bit ugly since `@boundscheck` returns `nothing`.
+    checked = false
+    @compat @boundscheck (checked = true;)
+    checked
+end
+@test do_boundscheck() == true
 if VERSION >= v"0.5.0-dev+2129"
-    bounds_checked = false
-    @compat @inbounds @boundscheck checkbounds()
-    @test !bounds_checked
+    do_boundscheck2() = (@inbounds c = do_boundscheck(); c)
+    @test do_boundscheck2() == false
 end


### PR DESCRIPTION
Fixes #182.

`@boundscheck` existed in 0.4, but had a very different meaning, being used internally by `@inbounds`.  There's no equivalent to the 0.5 meaning, so rewrite it to a no-op in `@compat`.

I returned `nothing` for consistency since the new `@boundscheck` has an `Expr(:boundscheck, :pop)` as the last statement in the block.  I'd be happy to hear if there's a more appropriate way to do this.