### PR TITLE
Support get(io, :compact, false) and get(io, :multiline, false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@compat Dict{Foo,Bar}(foo => bar, baz => qux)` - type-declared `Dict` construction. (Also works for `DataStructures.OrderedDict`)
 
-* `@compat(get(io, :limit, false))` to detect whether compressed output has been requested (performs useful work only on `v"0.5.0-dev+1936"`, defaults to `false` otherwise)
+* `@compat(get(io, s, false))`, with `s` equal to `:limit`, `:compact` or `:multiline`, to detect the corresponding print settings (performs useful work only on Julia 0.5, defaults to `false` otherwise)
 
 * `@compat split(str, splitter; keywords...)` - the Julia 0.4-style keyword-based `split` function
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -266,12 +266,22 @@ function rewrite_iocontext!(expr::Expr)
     if expr.head == :call && expr.args[1] == :get
         key = expr.args[3]
         if     (((isa(key, QuoteNode) && key.value == :limit) ||
-                 (isa(key, Expr) && key.head == :quote && key.args[1] == :limit))
+                 (isa(key, Expr) && key.head == :quote && key.args[1] == :limit) ||
+                ((isa(key, QuoteNode) && key.value == :compact) ||
+                 (isa(key, Expr) && key.head == :quote && key.args[1] == :compact)))
                 && expr.args[4] == false)
             if VERSION >= v"0.5.0-dev+1936" && VERSION < v"0.5.0-dev+4305"
                 expr.args[1] = :(Base.limit_output)
                 deleteat!(expr.args, 3:4)
             elseif VERSION < v"0.5.0-dev+1936"
+                expr.head = :quote
+                expr.args[1] = false
+                deleteat!(expr.args, 3:4)
+            end
+        elseif (((isa(key, QuoteNode) && key.value == :multiline) ||
+                 (isa(key, Expr) && key.head == :quote && key.args[1] == :multiline))
+                && expr.args[4] == false)
+            if VERSION < v"0.5.0-dev+4305"
                 expr.head = :quote
                 expr.args[1] = false
                 deleteat!(expr.args, 3:4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1188,3 +1188,5 @@ end
 
 io = IOBuffer()
 @test @compat(get(io, :limit, false)) == false
+@test @compat(get(io, :compact, false)) == false
+@test @compat(get(io, :multiline, false)) == false


### PR DESCRIPTION
These are the two other IOContext properties at the moment.
limit_output() was used to mean both limit=true and compact=true.