### PR TITLE
Fix qualified show rewrite

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -192,7 +192,7 @@ function rewrite_show(ex)
     if length(argtypes) == 2
         insert!(argtypes, 2, Expr(:(::), :macrocall, MIME"text/plain"))
     end
-    return Expr(:call, :writemime, argtypes...)
+    return Expr(:call, :(Base.writemime), argtypes...)
 end
 
 function rewrite_dict(ex)
@@ -456,7 +456,8 @@ function _compat(ex::Expr)
             rewrite_pairs_to_tuples!(ex)
         elseif VERSION < v"0.4.0-dev+1246" && f == :String
             ex = Expr(:call, :bytestring, ex.args[2:end]...)
-        elseif VERSION < v"0.5.0-dev+4340" && length(ex.args) > 2 && ex.args[1] === :show
+        elseif VERSION < v"0.5.0-dev+4340" && length(ex.args) > 2 &&
+                (macroexpand(ex.args[1]) in (:show, :(Base.show)))
             ex = rewrite_show(ex)
         end
         if VERSION < v"0.5.0-dev+4305"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -491,7 +491,7 @@ function _compat(ex::Expr)
         end
     elseif VERSION < v"0.4.0-dev+5322" && ex.head === :(::) && isa(ex.args[end], Symbol)
         # Replace Base.Timer with Compat.Timer2 in type declarations
-        if ex.args[end] === :Timer || ex.args[end] == :(Base.Timer)
+        if ex.args[end] === :Timer || macroexpand(ex.args[end]) == :(Base.Timer)
             ex.args[end] = :(Compat.Timer2)
         end
     elseif ex.head === :quote && isa(ex.args[1], Symbol)

--- a/src/nullable.jl
+++ b/src/nullable.jl
@@ -1,6 +1,10 @@
 import Base: eltype, convert, get, isequal, ==, hash, show
 export Nullable, NullException, isnull
 
+# FIXME: v0.3 on linux possibly has strange failure if this line, seemingly a
+# no-op, is excluded
+export eltype
+
 immutable Nullable{T}
     isnull::Bool
     value::T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType())
 @test @compat String(myio) == "MyTestCustomShowType"
 
 type TestCustomShowType2 end
-@compat show(io::IO, ::MIME"text/plain", ::TestCustomShowType2) = print(io, "MyTestCustomShowType2")
+@compat Base.show(io::IO, ::MIME"text/plain", ::TestCustomShowType2) = print(io, "MyTestCustomShowType2")
 myio = IOBuffer()
 display(TextDisplay(myio), MIME"text/plain"(), TestCustomShowType2())
 @test @compat String(myio) == "MyTestCustomShowType2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -448,8 +448,9 @@ if VERSION > v"0.3.99"
 end
 
 # Timer
-let c = 0, f, t
+let c = 0, f, g, t
     @compat f(t::Timer) = (c += 1)
+    @compat g(t::Base.Timer) = (c += 1)
     t = Timer(f, 0.0, 0.05)
     sleep(0.05)
     @test c >= 1
@@ -460,6 +461,10 @@ let c = 0, f, t
     val = c
     sleep(0.1)
     @test val == c
+    t = Timer(g, 0.0, 0.05)
+    sleep(0.05)
+    @test c >= 2
+    close(t)
 end
 
 # MathConst -> Irrational


### PR DESCRIPTION
This addresses the missing case in #219.

Could a new version be tagged soon? I got hit by this when updating Hiccup. Hiccup tests also didn't catch it, so luckily I double checked! (I noticed the omission in the original PR, but since tests passed I thought it might have been fixed in the interim.)

While debugging this, I noticed that the `Base.Timer` rewrite was untested and didn't actually work. I decided to fix that along the way.