### PR TITLE
Disable test using features removed from v0.5

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,7 +399,9 @@ end
 # Cstring
 let s = "foo", w = wstring("foo")
     @test reinterpret(Ptr{Cchar}, Compat.unsafe_convert(Cstring, s)) == pointer(s)
-    @test reinterpret(Ptr{Cwchar_t}, Compat.unsafe_convert(Cwstring, w)) == pointer(w)
+    if VERSION < v"0.5.0-dev+4859"
+        @test reinterpret(Ptr{Cwchar_t}, Compat.unsafe_convert(Cwstring, w)) == pointer(w)
+    end
 end
 
 # fma and muladd


### PR DESCRIPTION
This disables the test for `unsafe_convert` methods removed in v0.5. Should fix the nightly failures (there are still deprecation warnings).