### PR TITLE
Remove rewriting of two-argument show

### DIFF
--- a/src/nullable.jl
+++ b/src/nullable.jl
@@ -1,10 +1,6 @@
 import Base: eltype, convert, get, isequal, ==, hash, show
 export Nullable, NullException, isnull
 
-# FIXME: v0.3 on linux possibly has strange failure if this line, seemingly a
-# no-op, is excluded
-export eltype
-
 immutable Nullable{T}
     isnull::Bool
     value::T


### PR DESCRIPTION
On v0.4 and before, it is correct to define two-argument `Base.show`, and there is an automatic fallback for three-argument `Base.writemime` with `MIME("text/plain")`. However the previous rewriting was rewriting two-argument `Base.show` to three-argument `Base.writemime`, which broke JuMP's tests. This removes that unnecessary rewriting.

The rest of the changes are general cleanups that are unrelated to the JuMP failure. I removed the extra `export` in hopes that fiddling with the code would fix whatever problem required it.