### PR TITLE
Add type assertion to `Symbol` method. Fix #242

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -397,7 +397,7 @@ if VERSION < v"0.4.0-dev+3732"
         calltypes[k] = v
     end
 elseif VERSION < v"0.5.0-dev+3831"
-    Base.Symbol(args...) = symbol(args...)
+    Base.Symbol(args...) = symbol(args...)::Symbol
 end
 
 if VERSION < v"0.5.0-dev+2396"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,6 +1160,8 @@ if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("a_", 2) === :a_2
     @test Symbol('c') === :c
     @test Symbol(1) === Symbol("1")
+    # Behaviour on 0.5 might change JuliaLang/julia#7258
+    @test keytype([Symbol(k) => v for (k,v) in Dict{Any, Any}(:x=>3)]) == Symbol
 end
 
 foostring(::String) = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,8 +1160,6 @@ if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("a_", 2) === :a_2
     @test Symbol('c') === :c
     @test Symbol(1) === Symbol("1")
-    # Behaviour on 0.5 might change JuliaLang/julia#7258
-    @test keytype([Symbol(k) => v for (k,v) in Dict{Any, Any}(:x=>3)]) == Symbol
 end
 
 foostring(::String) = 1


### PR DESCRIPTION
@yuyichao @nalimilan Tested DataFrames, PyCall and SciktiLearn on Julia 0.4.5, all tests passed.