### PR TITLE
unsafe_string should accept both UInt8 and Int8 pointer type

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1277,7 +1277,7 @@ else
 end
 
 if !isdefined(Base, :view)
-    const view = slice 
+    const view = slice
 end
 
 if !isdefined(Base, :pointer_to_string)
@@ -1298,8 +1298,8 @@ if VERSION < v"0.5.0-dev+4612"
     unsafe_wrap(::Type{Compat.String}, p::Ptr, own::Bool=false) = pointer_to_string(p, own)
     unsafe_wrap(::Type{Compat.String}, p::Ptr, len, own::Bool=false) = pointer_to_string(p, len, own)
     unsafe_wrap(::Type{Array}, p::Ptr, dims, own::Bool=false) = pointer_to_array(p, dims, own)
-    unsafe_string(p::Ptr{UInt8}) = bytestring(p)
-    unsafe_string(p::Ptr{UInt8}, len) = bytestring(p, len)
+    unsafe_string(p::Union{Ptr{Int8},Ptr{UInt8}}) = bytestring(p)
+    unsafe_string(p::Union{Ptr{Int8},Ptr{UInt8}}, len) = bytestring(p, len)
     if Cstring != Ptr{UInt8}
         unsafe_string(p::Cstring) = unsafe_string(Ptr{UInt8}(p))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1224,6 +1224,7 @@ io = IOBuffer()
 let
     test_str = "test"
     ptr = pointer(test_str.data)
+    signedptr = Ptr{Int8}(ptr)
     wrapped_str = unsafe_wrap(Compat.String, ptr)
     new_str = unsafe_string(ptr)
     cstr = convert(Cstring, ptr)
@@ -1231,6 +1232,9 @@ let
     @test wrapped_str == "test"
     @test new_str == "test"
     @test new_str2 == "test"
+    @test unsafe_string(signedptr) == test_str
+    @test unsafe_string(ptr, 4) == test_str
+    @test unsafe_string(signedptr, 4) == test_str
     @test ptr == pointer(wrapped_str)  # Test proper pointer aliasing behavior
     @test ptr ≠ pointer(new_str)
     @test ptr ≠ pointer(new_str2)
@@ -1246,5 +1250,5 @@ end
 
 # Add test for Base.view
 let a = rand(10,10)
-    @test view(a, :, 1) == a[:,1] 
+    @test view(a, :, 1) == a[:,1]
 end


### PR DESCRIPTION
As Julia master does:

```jl
julia> methods(unsafe_string)
# 3 methods for generic function "unsafe_string":
unsafe_string(s::Cstring) at c.jl:69
unsafe_string(p::Union{Ptr{Int8},Ptr{UInt8}}) at strings/basic.jl:56
unsafe_string(p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) at strings/basic.jl:52

julia> versioninfo()
Julia Version 0.5.0-dev+5063
Commit 8ecd657* (2016-07-01 04:21 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin15.5.0)
  CPU: Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.7.1 (ORCJIT, haswell)
```

Without this, e.g. the following doesn't work (on v0.4.5 at least):

```jl
using Compat
unsafe_string(ccall((:getenv, "libc"), Ptr{Cchar}, (Ptr{UInt8},),
            Compat.unsafe_convert(Ptr{UInt8}, "HOME")))
```
```
LoadError: MethodError: `unsafe_string` has no method matching unsafe_string(::Ptr{Int8})
while loading In[28], in expression starting on line 1
```

when Cchar is aliased to Int8.