### PR TITLE
accept Ptr{Int8} in unsafe_string and unsafe_wrap

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1301,11 +1301,11 @@ end
 
 if VERSION < v"0.5.0-dev+4612"
     export unsafe_string, unsafe_wrap
-    unsafe_wrap(::Type{Compat.String}, p::Ptr, own::Bool=false) = pointer_to_string(p, own)
-    unsafe_wrap(::Type{Compat.String}, p::Ptr, len, own::Bool=false) = pointer_to_string(p, len, own)
+    unsafe_wrap(::Type{Compat.String}, p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), own::Bool=false) = pointer_to_string(convert(Ptr{UInt8}, p), own)
+    unsafe_wrap(::Type{Compat.String}, p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), len, own::Bool=false) = pointer_to_string(convert(Ptr{UInt8}, p), len, own)
     unsafe_wrap(::Type{Array}, p::Ptr, dims, own::Bool=false) = pointer_to_array(p, dims, own)
-    unsafe_string(p::Ptr{UInt8}) = bytestring(p)
-    unsafe_string(p::Ptr{UInt8}, len) = bytestring(p, len)
+    unsafe_string(p::@compat(Union{Ptr{Int8},Ptr{UInt8}})) = bytestring(p)
+    unsafe_string(p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), len) = bytestring(p, len)
     if Cstring != Ptr{UInt8}
         unsafe_string(p::Cstring) = unsafe_string(Ptr{UInt8}(p))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1242,6 +1242,8 @@ let
     @test ptr == pointer(wrapped_str)  # Test proper pointer aliasing behavior
     @test ptr ≠ pointer(new_str)
     @test ptr ≠ pointer(new_str2)
+    @test unsafe_string(convert(Ptr{Int8}, ptr)) == "test"
+    @test unsafe_wrap(Compat.String, convert(Ptr{Int8}, ptr)) == "test"
     x = [1, 2]
     @test unsafe_wrap(Array, pointer(x), 2) == [1, 2]
 end


### PR DESCRIPTION
This fixes `unsafe_string` and `unsafe_wrap` so that they accept both `Ptr{Int8}` and `Ptr{UInt8}`, like the functions in Base.

This should supersede #244.  (Sorry for the duplication, @r9y9; I prepared this patch yesterday but didn't have a chance to push it until now.)