### PR TITLE
Fix broadcast_shape when Base.OneTo is defined

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1316,4 +1316,9 @@ if !isdefined(Base, :allunique)
     export allunique
 end
 
+if isdefined(Base, :OneTo)
+    broadcast_shape(x...) = Base.to_shape(broadcast_shape(x...))
+    export broadcast_shape
+end
+
 end # module


### PR DESCRIPTION
This provides a workaround for `broadcast_shape` differences introduced by `Base.OneTo` in JuliaLang/julia#17137. This is the approach used by DataArrays developed by @tkelman and @timholy.