### PR TITLE
Provide promote_eltype_op

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `walkdir`, returns an iterator that walks the directory tree of a directory. ([#13707](https://github.com/JuliaLang/julia/pull/13707))
 
 * `allunique`, checks whether all elements in an iterable appear only once ([#15914](https://github.com/JuliaLang/julia/pull/15914)).
+* `Base.promote_eltype_op` is available as `Compat.promote_eltype_op`; however, in Julia 0.3, results may be inaccurate.
 
 ## Renamed functions
 
@@ -196,7 +197,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `write(::IO, ::Ptr, len)` is now `unsafe_write` [#14766](https://github.com/JuliaLang/julia/pull/14766).
 
-* `slice` is now `view`[#16972](https://github.com/JuliaLang/julia/pull/16972) do `import Compat.view` and then use `view` normally without the `@compat` macro. 
+* `slice` is now `view`[#16972](https://github.com/JuliaLang/julia/pull/16972) do `import Compat.view` and then use `view` normally without the `@compat` macro.
 
 ## New macros
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1322,4 +1322,26 @@ if !isdefined(Base, :allunique)
     export allunique
 end
 
+if !isdefined(Base, :promote_eltype_op)
+    if isdefined(Base, :promote_op)
+        promote_eltype_op(::Any) = Union{}
+        promote_eltype_op{T}(op, ::AbstractArray{T}) = Base.promote_op(op, T)
+        promote_eltype_op{T}(op, ::T               ) = Base.promote_op(op, T)
+        promote_eltype_op{R,S}(op, ::AbstractArray{R}, ::AbstractArray{S}) = Base.promote_op(op, R, S)
+        promote_eltype_op{R,S}(op, ::AbstractArray{R}, ::S) = Base.promote_op(op, R, S)
+        promote_eltype_op{R,S}(op, ::R, ::AbstractArray{S}) = Base.promote_op(op, R, S)
+        promote_eltype_op(op, A, B, C, D...) = Base.promote_op(op, eltype(A), promote_eltype_op(op, B, C, D...))
+    else
+        promote_eltype_op(::Any) = Union{}
+        promote_eltype_op{T}(op, ::AbstractArray{T}) = T
+        promote_eltype_op{T}(op, ::T               ) = T
+        promote_eltype_op{R,S}(op, ::AbstractArray{R}, ::AbstractArray{S}) = Base.promote_type(R, S)
+        promote_eltype_op{R,S}(op, ::AbstractArray{R}, ::S) = Base.promote_type(R, S)
+        promote_eltype_op{R,S}(op, ::R, ::AbstractArray{S}) = Base.promote_type(R, S)
+        promote_eltype_op(op, A, B, C, D...) = Base.promote_type(eltype(A), promote_eltype_op(op, B, C, D...))
+    end
+else
+    import Base.promote_eltype_op
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1268,6 +1268,7 @@ let a = rand(10,10)
     @test view(a, :, 1) == a[:,1]
 end
 
+
 # 0.5 style single argument `@boundscheck`
 @inline function do_boundscheck()
     # A bit ugly since `@boundscheck` returns `nothing`.
@@ -1276,3 +1277,6 @@ end
     checked
 end
 @test do_boundscheck() == true
+
+@test Compat.promote_eltype_op(@functorize(+), ones(2,2), 1) === Float64
+@test Compat.promote_eltype_op(@functorize(*), ones(Int, 2), zeros(Int16,2)) === Int


### PR DESCRIPTION
Needed due to https://github.com/JuliaLang/julia/pull/17398.

For Julia 0.3, which lacks `promote_op`, the definition is questionable. Maybe better only provide `promote_eltype_op` for Julia 0.4?