### PR TITLE
adds AsyncCondition that's more compliant with 0.5 version

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1101,7 +1101,36 @@ if !isdefined(Base, :Threads)
 end
 
 if !isdefined(Base, :AsyncCondition)
-    const AsyncCondition = Base.SingleAsyncWork
+    type AsyncCondition
+        cond::Condition
+        handle::Ptr{Void}
+
+        function AsyncCondition(func=nothing)
+            this = new(Condition())
+            # the callback is supposed to be called with this AsyncCondition
+            # as the argument, so we need to create a wrapper callback
+            if func == nothing
+                function wrapfunc(data)
+                    notify(this.cond)
+
+                    nothing
+                end
+            else
+                function wrapfunc(data)
+                    notify(this.cond)
+                    func(this)
+
+                    nothing
+                end
+            end
+            work = Base.SingleAsyncWork(wrapfunc)
+            this.handle = work.handle
+
+            this
+        end
+    end
+
+    Base.wait(c::AsyncCondition) = wait(c.cond)
 else
     import Base.AsyncCondition
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1201,6 +1201,18 @@ let async, c = false
     @test c
 end
 
+let async, c = false
+    async = Compat.AsyncCondition()
+    @schedule begin
+        wait(async)
+        c = true
+    end
+    sleep(0.1)
+    ccall(:uv_async_send, Void, (Ptr{Void},), async.handle)
+    sleep(0.1)
+    @test c
+end
+
 let io = IOBuffer(), s = "hello"
     unsafe_write(io, pointer(s), length(s))
     @test takebuf_string(io) == s


### PR DESCRIPTION
This adds the ability to use `AsyncCondition()` (without giving a callback function) to make a thing that can be `wait`ed on, like the `AsyncCondition` type in 0.5. To simplify, it's built on top of `SingleAsyncWork`.