### PR TITLE
Provide three-argument `show`

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `print_escaped` is now another method of `escape_string`, `print_unescaped` a method of `unescape_string`, and `print_joined` a method of `join`. [#16603](https://github.com/JuliaLang/julia/pull/16603)
 
+* `writemime` has been merged into `show` [#16563](https://github.com/JuliaLang/julia/pull/16563). Note that to extend this function requires `@compat`; see the [Supported Syntax](#supported-syntax) section for more information.
+
 ## New macros
 
 * `@static` has been added [#16219](https://github.com/JuliaLang/julia/pull/16219).

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1438,4 +1438,8 @@ if VERSION < v"0.5.0-dev+4351"
         print_escaped(io, str, esc)
 end
 
+if VERSION < v"0.5.0-dev+4340"
+    Base.show(io::IO, mime, x) = writemime(io, mime, x)
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1344,3 +1344,6 @@ end
 @test sprint(join, [1, 2, 3], ", ", ", and ") == "1, 2, and 3"
 @test sprint(escape_string, "xyz\n", "z") == "xy\\z\\n"
 @test sprint(unescape_string, "xyz\\n") == "xyz\n"
+
+# three-argument show from JuliaLang/julia#16563
+@test sprint(show, "text/plain", 1) == stringmime("text/plain", 1)


### PR DESCRIPTION
As @stevengj [noted](https://github.com/JuliaLang/Compat.jl/pull/219#issuecomment-237624722), and I recently ran into, this provides three-argument `show` on v0.4 and earlier. This is not only convenient, but is necessary in situations where `show` must be passed around as a function.