### PR TITLE
Compat for at-vectorize_(1|2)arg deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@__DIR__` has been added [#18380](https://github.com/JuliaLang/julia/pull/18380)
 
+* `@vectorize_1arg` and `@vectorize_2arg` are deprecated on Julia 0.6 in favor
+  of the broadcast syntax [#17302](https://github.com/JuliaLang/julia/pull/17302).
+  `Compat.@dep_vectorize_1arg` and `Compat.@dep_vectorize_2arg` are provided
+  so that packages can still provide the deprecated definitions
+  without causing a depwarn in the package itself before all the users
+  are upgraded.
+
+  Packages are expected to use this until all users of the deprecated
+  vectorized function have migrated. These macros will be dropped when
+  the support for `0.6` is dropped from `Compat`.
+
 ## Other changes
 
 * `remotecall`, `remotecall_fetch`, `remotecall_wait`, and `remote_do` have the function to be executed remotely as the first argument in Julia 0.5. Loading `Compat` defines the same methods in older versions of Julia. [#13338](https://github.com/JuliaLang/julia/pull/13338)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1464,8 +1464,49 @@ if VERSION < v"0.6.0-dev.374"
 end
 
 if VERSION < v"0.6.0-dev.528"
-    macro __DIR__() Base.source_dir() end
+    macro __DIR__()
+        Base.source_dir()
+    end
     export @__DIR__
+end
+
+# PR #17302
+# Provide a non-deprecated version of `@vectorize_(1|2)arg` macro which defines
+# deprecated version of the function so that the depwarns can be fixed without
+# breaking users.
+# Packages are expected to use this to maintain the old API until all users
+# of the deprecated vectorized function have migrated.
+# These macros should raise a depwarn when the `0.5` support is dropped from
+# `Compat` and be dropped when the support for `0.6` is dropped from `Compat`.
+# Modified based on the version copied from 0.6 Base.
+macro dep_vectorize_1arg(S, f)
+    S = esc(S)
+    f = esc(f)
+    T = esc(:T)
+    x = esc(:x)
+    AbsArr = esc(:AbstractArray)
+    ## Depwarn to be enabled when 0.5 support is dropped.
+    # depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+    #         Symbol("@dep_vectorize_1arg"))
+    :(@deprecate $f{$T<:$S}($x::$AbsArr{$T}) @compat($f.($x)))
+end
+
+macro dep_vectorize_2arg(S, f)
+    S = esc(S)
+    f = esc(f)
+    T1 = esc(:T1)
+    T2 = esc(:T2)
+    x = esc(:x)
+    y = esc(:y)
+    AbsArr = esc(:AbstractArray)
+    ## Depwarn to be enabled when 0.5 support is dropped.
+    # depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+    #         Symbol("@dep_vectorize_2arg"))
+    quote
+        @deprecate $f{$T1<:$S}($x::$S, $y::$AbsArr{$T1}) @compat($f.($x,$y))
+        @deprecate $f{$T1<:$S}($x::$AbsArr{$T1}, $y::$S) @compat($f.($x,$y))
+        @deprecate $f{$T1<:$S,$T2<:$S}($x::$AbsArr{$T1}, $y::$AbsArr{$T2}) @compat($f.($x,$y))
+    end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1182,6 +1182,36 @@ let x = rand(3), y = rand(3)
     @test @compat(sin.(cos.(x))) == map(x -> sin(cos(x)), x)
     @test @compat(atan2.(sin.(y),x)) == broadcast(atan2,map(sin,y),x)
 end
+let x0 = Array(Float64), v, v0
+    x0[1] = rand()
+    v0 = @compat sin.(x0)
+    @test isa(v0, Array{Float64,0})
+    v = @compat sin.(x0[1])
+    @test isa(v, Float64)
+    @test v == v0[1] == sin(x0[1])
+end
+let x = rand(2, 2), v
+    v = @compat sin.(x)
+    @test isa(v, Array{Float64,2})
+    @test v == [sin(x[1, 1]) sin(x[1, 2]);
+                sin(x[2, 1]) sin(x[2, 2])]
+end
+let x1 = [1, 2, 3], x2 = ([3, 4, 5],), v
+    v = @compat atan2.(x1, x2...)
+    @test isa(v, Vector{Float64})
+    @test v == [atan2(1, 3), atan2(2, 4), atan2(3, 5)]
+end
+# Do the following in global scope to make sure inference is able to handle it
+@test @compat(sin.([1, 2])) == [sin(1), sin(2)]
+@test isa(@compat(sin.([1, 2])), Vector{Float64})
+@test @compat(atan2.(1, [2, 3])) == [atan2(1, 2), atan2(1, 3)]
+@test isa(@compat(atan2.(1, [2, 3])), Vector{Float64})
+@test @compat(atan2.([1, 2], [2, 3])) == [atan2(1, 2), atan2(2, 3)]
+@test isa(@compat(atan2.([1, 2], [2, 3])), Vector{Float64})
+# And make sure it is actually inferrable
+f15032(a) = @compat sin.(a)
+@inferred f15032([1, 2, 3])
+@inferred f15032([1.0, 2.0, 3.0])
 
 if VERSION ≥ v"0.4.0-dev+3732"
     @test Symbol("foo") === :foo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1115,7 +1115,7 @@ for (Fun, func) in [(:AndFun,              :&),
                     (:DotMulFun,           :.*),
                     (:RDivFun,             :/),
                     (:DotRDivFun,          :./),
-                    (:LDivFun,             :\),
+                    (:LDivFun,             :\ ),
                     (:IDivFun,             :div),
                     (:DotIDivFun,          @compat(Symbol(".÷"))),
                     (:ModFun,              :mod),
@@ -1383,3 +1383,20 @@ let filename = tempname()
 end
 
 @test @__DIR__() == dirname(@__FILE__)
+
+# PR #17302
+# To be removed when 0.5/0.6 support is dropped.
+f17302(a::Number) = a
+f17302(a::Number, b::Number) = a + b
+Compat.@dep_vectorize_1arg Real f17302
+Compat.@dep_vectorize_2arg Real f17302
+@test_throws MethodError f17302([1im])
+@test_throws MethodError f17302([1im], [1im])
+mktemp() do fname, f
+    redirect_stderr(f) do
+        @test f17302([1.0]) == [1.0]
+        @test f17302(1.0, [1]) == [2.0]
+        @test f17302([1.0], 1) == [2.0]
+        @test f17302([1.0], [1]) == [2.0]
+    end
+end


### PR DESCRIPTION
Provide `Compat.@vectorize_1arg` and `Compat.@vectorize_2arg` as an upgrade
path for packages.