### PR TITLE
fix test script for changes in warn() escape codes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1397,7 +1397,7 @@ let filename = tempname()
     @test chomp(readstring(filename)) == "hello"
     ret = open(filename, "w") do f
         redirect_stderr(f) do
-            warn("hello")
+            println(STDERR, "WARNING: hello")
             [2]
         end
     end


### PR DESCRIPTION
One of the tests got broken by JuliaLang/julia#18628, as discussed in JuliaLang/julia#19682