### PR TITLE
Add ShortCircuiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `bytestring` has been replaced in most cases with additional `String` construction methods; for 0.4 compatibility, the usage involves replacing `bytestring(args...)` with `Compat.String(args...)`. However, for converting a `Ptr{UInt8}` to a string, use the new `unsafe_string(...)` method to make a copy or `unsafe_wrap(String, ...)` to avoid a copy.
 
+* The unexported type alias `Base.ShortCircuiting` was removed in [#19543](https://github.com/JuliaLang/julia/pull/19543). On 0.4
+  it was the union of the unexported `Base.AndFun` and `Base.OrFun` functor types, then once functions became their own types, the
+  definition changed to the union of `typeof(&)` and `typeof(|)`. `ShortCircuiting` remains unexported from Compat.
+
 ## New functions
 
 * `foreach`, similar to `map` but when the return value is not needed ([#13744](https://github.com/JuliaLang/julia/pull/13774)).

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1724,4 +1724,11 @@ if VERSION < v"0.5.0-dev+5380"
     end
 end
 
+# Julia #19543 (removes ShortCircuiting)
+if VERSION < v"0.5.0-dev+3701"
+    typealias ShortCircuiting Union{Base.AndFun, Base.OrFun}
+else
+    typealias ShortCircuiting Union{typeof(&), typeof(|)}
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1534,3 +1534,9 @@ let s = "Koala test: 🐨"
         @test transcode(T, s) == transcode(T, s.data) == transcode(T, transcode(T, s))
     end
 end
+
+if typeof(&) == Function # before functions had their own types
+    @test Compat.ShortCircuiting === Union{Base.AndFun, Base.OrFun}
+else
+    @test Compat.ShortCircuiting === Union{typeof(&), typeof(|)}
+end


### PR DESCRIPTION
This works around the removal of `Base.ShortCircuiting` in Julia 0.6 by providing `Compat.ShortCircuiting`, which retains the definition from Base on previous versions.

cc @tkelman 