### PR TITLE
Backport ∘ and ! from #17155

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `transcode` converts between UTF-xx string encodings in Julia 0.5 (as a lightweight
    alternative to the LegacyStrings package), [#17323](https://github.com/JuliaLang/julia/pull/17323).
 
+* `∘` (typically used infix as `f ∘ g`) for function composition can be used in 0.5 and earlier. [#17155](https://github.com/JuliaLang/julia/pull/17155)
+
+* The method of `!` to negate functions (typically used as a unary operator, as in `!isinteger`) can be used in 0.5 and earlier. [#17155](https://github.com/JuliaLang/julia/pull/17155)
+
 ## Renamed functions
 
 * `pointer_to_array` and `pointer_to_string` have been replaced with `unsafe_wrap(Array, ...)` and `unsafe_wrap(String, ...)` respectively.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1739,4 +1739,11 @@ if VERSION < v"0.5.0-dev+5380"
     end
 end
 
+# julia #17155 function composition and negation
+if VERSION < v"0.6.0-dev.1883"
+    export ∘
+    ∘(f, g) = (x...)->f(g(x...))
+    @compat Base.:!(f::Function) = (x...)->!f(x...)
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1544,3 +1544,10 @@ let s = "Koala test: 🐨"
         @test transcode(T, s) == transcode(T, s.data) == transcode(T, transcode(T, s))
     end
 end
+
+# julia#17155, tests from Base Julia
+@test (uppercase∘hex)(239487) == "3A77F"
+let str = randstring(20)
+    @test filter(!isupper, str) == replace(str, r"[A-Z]", "")
+    @test filter(!islower, str) == replace(str, r"[a-z]", "")
+end


### PR DESCRIPTION
This makes ∘ and ! available for 0.5 and prior.