### PR TITLE
Add .& and .|

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The method of `!` to negate functions (typically used as a unary operator, as in `!isinteger`) can be used in 0.5 and earlier. [#17155](https://github.com/JuliaLang/julia/pull/17155)
 
+* `.&` and `.|` are short syntax for `broadcast(&, xs...)` and `broadcast(|, xs...)` (respectively) in Julia 0.6 (only supported on Julia 0.5 and above) [#17623](https://github.com/JuliaLang/julia/pull/17623)
+
 ## Renamed functions
 
 * `pointer_to_array` and `pointer_to_string` have been replaced with `unsafe_wrap(Array, ...)` and `unsafe_wrap(String, ...)` respectively

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1759,4 +1759,11 @@ if VERSION < v"0.5.0-dev+3669"
         scale!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), D.diag, A)
 end
 
+if VERSION >= v"0.5.0-dev+5509" && VERSION < v"0.6.0-dev.1614"
+    # To work around unsupported syntax on Julia 0.4
+    include_string("export .&, .|")
+    include_string(".&(xs...) = broadcast(&, xs...)")
+    include_string(".|(xs...) = broadcast(|, xs...)")
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1577,3 +1577,9 @@ D = Diagonal(x)
 A = view(rand(5,5), 1:3, 1:3)
 @test D*A == Diagonal(copy(x)) * copy(A)
 @test A*D == copy(A) * Diagonal(copy(x))
+
+# julia#17623
+@static if VERSION >= v"0.5.0-dev+5509" # To work around unsupported syntax on Julia 0.4
+    @test [true, false] .& [true, true] == [true, false]
+    @test [true, false] .| [true, true] == [true, true]
+end


### PR DESCRIPTION
These replace element-wise & and |, which are deprecated in Julia 0.6.
This syntax is not supported on 0.4 (raises a deprecation warning).

(Failure on nightlies is unrelated.)