### PR TITLE
Fix Compat on master by updating walkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.isapprox` with `nans` keyword argument [#20022](https://github.com/JuliaLang/julia/pull/20022)
 
+* `take!` method for `Task`s since some functions now return `Channel`s instead of `Task`s [#19841](https://github.com/JuliaLang/julia/pull/19841).
+
 ## Renamed functions
 
 * `pointer_to_array` and `pointer_to_string` have been replaced with `unsafe_wrap(Array, ...)` and `unsafe_wrap(String, ...)` respectively

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -F -e "versioninfo();
+  - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"Compat\"); Pkg.build(\"Compat\")"
 
 test_script:

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -194,6 +194,9 @@ if VERSION < v"0.5.0-dev+961"
         Task(_it)
     end
 end
+if VERSION < v"0.6.0-dev.2043"
+    Base.take!(t::Task) = consume(t)
+end
 
 function rewrite_show(ex)
     if isexpr(ex, :call)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -983,29 +983,29 @@ cd(dirwalk) do
     follow_symlink_vec = has_symlinks ? [true, false] : [false]
     has_symlinks && symlink(abspath("sub_dir2"), joinpath("sub_dir1", "link"))
     for follow_symlinks in follow_symlink_vec
-        task = walkdir(".", follow_symlinks=follow_symlinks)
-        root, dirs, files = consume(task)
+        chnl = walkdir(".", follow_symlinks=follow_symlinks)
+        root, dirs, files = take!(chnl)
         @test root == "."
         @test dirs == ["sub_dir1", "sub_dir2"]
         @test files == ["file1", "file2"]
 
-        root, dirs, files = consume(task)
+        root, dirs, files = take!(chnl)
         @test root == joinpath(".", "sub_dir1")
         @test dirs == (has_symlinks ? ["link", "subsub_dir1", "subsub_dir2"] : ["subsub_dir1", "subsub_dir2"])
         @test files == ["file1", "file2"]
 
-        root, dirs, files = consume(task)
+        root, dirs, files = take!(chnl)
         if follow_symlinks
             @test root == joinpath(".", "sub_dir1", "link")
             @test dirs == []
             @test files == ["file_dir2"]
-            root, dirs, files = consume(task)
+            root, dirs, files = take!(chnl)
         end
         for i=1:2
             @test root == joinpath(".", "sub_dir1", "subsub_dir$i")
             @test dirs == []
             @test files == []
-            root, dirs, files = consume(task)
+            root, dirs, files = take!(chnl)
         end
 
         @test root == joinpath(".", "sub_dir2")
@@ -1014,51 +1014,51 @@ cd(dirwalk) do
     end
 
     for follow_symlinks in follow_symlink_vec
-        task = walkdir(".", follow_symlinks=follow_symlinks, topdown=false)
-        root, dirs, files = consume(task)
+        chnl = walkdir(".", follow_symlinks=follow_symlinks, topdown=false)
+        root, dirs, files = take!(chnl)
         if follow_symlinks
             @test root == joinpath(".", "sub_dir1", "link")
             @test dirs == []
             @test files == ["file_dir2"]
-            root, dirs, files = consume(task)
+            root, dirs, files = take!(chnl)
         end
         for i=1:2
             @test root == joinpath(".", "sub_dir1", "subsub_dir$i")
             @test dirs == []
             @test files == []
-            root, dirs, files = consume(task)
+            root, dirs, files = take!(chnl)
         end
         @test root == joinpath(".", "sub_dir1")
         @test dirs ==  (has_symlinks ? ["link", "subsub_dir1", "subsub_dir2"] : ["subsub_dir1", "subsub_dir2"])
         @test files == ["file1", "file2"]
 
-        root, dirs, files = consume(task)
+        root, dirs, files = take!(chnl)
         @test root == joinpath(".", "sub_dir2")
         @test dirs == []
         @test files == ["file_dir2"]
 
-        root, dirs, files = consume(task)
+        root, dirs, files = take!(chnl)
         @test root == "."
         @test dirs == ["sub_dir1", "sub_dir2"]
         @test files == ["file1", "file2"]
     end
     #test of error handling
-    task_error = walkdir(".")
-    task_noerror = walkdir(".", onerror=x->x)
-    root, dirs, files = consume(task_error)
+    chnl_error = walkdir(".")
+    chnl_noerror = walkdir(".", onerror=x->x)
+    root, dirs, files = take!(chnl_error)
     @test root == "."
     @test dirs == ["sub_dir1", "sub_dir2"]
     @test files == ["file1", "file2"]
 
     rm(joinpath("sub_dir1"), recursive=true)
-    @test_throws SystemError consume(task_error) # throws an error because sub_dir1 do not exist
+    @test_throws SystemError take!(chnl_error) # throws an error because sub_dir1 do not exist
 
-    root, dirs, files = consume(task_noerror)
+    root, dirs, files = take!(chnl_noerror)
     @test root == "."
     @test dirs == ["sub_dir1", "sub_dir2"]
     @test files == ["file1", "file2"]
 
-    root, dirs, files = consume(task_noerror) # skips sub_dir1 as it no longer exist
+    root, dirs, files = take!(chnl_noerror) # skips sub_dir1 as it no longer exist
     @test root == joinpath(".", "sub_dir2")
     @test dirs == []
     @test files == ["file_dir2"]
@@ -1192,7 +1192,7 @@ let x = rand(3), y = rand(3)
     @test @compat(sin.(cos.(x))) == map(x -> sin(cos(x)), x)
     @test @compat(atan2.(sin.(y),x)) == broadcast(atan2,map(sin,y),x)
 end
-let x0 = Array(Float64), v, v0
+let x0 = Array{Float64}(), v, v0
     x0[1] = rand()
     v0 = @compat sin.(x0)
     @test isa(v0, Array{Float64,0})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,10 +1160,13 @@ end
 let a = rand(1:10, 10)
     @test mapreduce(identity, dot, a) == mapreduce(identity, @functorize(dot), a)
 end
-@test isa(@functorize(centralizedabs2fun)(1), @functorize(centralizedabs2fun))
-@test isa(@functorize(centralizedabs2fun)(1.0), @functorize(centralizedabs2fun))
-let a = rand(1:10, 10)
-    @eval @test mapreduce(x -> abs2(x - 1), +, $(a)) == mapreduce(@functorize(centralizedabs2fun)(1), +, $(a))
+
+if VERSION < v"0.6.0-dev.2521"
+    @test isa(@functorize(centralizedabs2fun)(1), @functorize(centralizedabs2fun))
+    @test isa(@functorize(centralizedabs2fun)(1.0), @functorize(centralizedabs2fun))
+    let a = rand(1:10, 10)
+        @eval @test mapreduce(x -> abs2(x - 1), +, $(a)) == mapreduce(@functorize(centralizedabs2fun)(1), +, $(a))
+    end
 end
 
 # Threads.@threads

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,35 +98,37 @@ if VERSION < v"0.4.0-dev+1387"
     @test isdefined(Main, :AbstractString)
 end
 
-@test round(Int, 3//4) == 1
-@test round(Int, 1) == 1
-@test round(Int, 1.1) == 1
-@test round(Int, [1, 1]) == [1, 1]
-@test round(Int, [1.1, 1.1]) == [1, 1]
-@test round(Int, [1 1]) == [1 1]
-@test round(Int, [1.1 1.1]) == [1 1]
-@test round(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
-@test ceil(Int, 1) == 1
-@test ceil(Int, 1.1) == 2
-@test ceil(Int, [1, 1]) == [1, 1]
-@test ceil(Int, [1.1, 1.1]) == [2, 2]
-@test ceil(Int, [1 1]) == [1 1]
-@test ceil(Int, [1.1 1.1]) == [2 2]
-@test ceil(Int, fill(1.1, 2, 3, 4)) == fill(2, 2, 3, 4)
-@test floor(Int, 1) == 1
-@test floor(Int, 1.1) == 1
-@test floor(Int, [1, 1]) == [1, 1]
-@test floor(Int, [1.1, 1.1]) == [1, 1]
-@test floor(Int, [1 1]) == [1 1]
-@test floor(Int, [1.1 1.1]) == [1 1]
-@test floor(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
-@test trunc(Int, 1) == 1
-@test trunc(Int, 1.1) == 1
-@test trunc(Int, [1, 1]) == [1, 1]
-@test trunc(Int, [1.1, 1.1]) == [1, 1]
-@test trunc(Int, [1 1]) == [1 1]
-@test trunc(Int, [1.1 1.1]) == [1 1]
-@test trunc(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
+if VERSION < v"0.6.0-"
+    @test round(Int, 3//4) == 1
+    @test round(Int, 1) == 1
+    @test round(Int, 1.1) == 1
+    @test round(Int, [1, 1]) == [1, 1]
+    @test round(Int, [1.1, 1.1]) == [1, 1]
+    @test round(Int, [1 1]) == [1 1]
+    @test round(Int, [1.1 1.1]) == [1 1]
+    @test round(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
+    @test ceil(Int, 1) == 1
+    @test ceil(Int, 1.1) == 2
+    @test ceil(Int, [1, 1]) == [1, 1]
+    @test ceil(Int, [1.1, 1.1]) == [2, 2]
+    @test ceil(Int, [1 1]) == [1 1]
+    @test ceil(Int, [1.1 1.1]) == [2 2]
+    @test ceil(Int, fill(1.1, 2, 3, 4)) == fill(2, 2, 3, 4)
+    @test floor(Int, 1) == 1
+    @test floor(Int, 1.1) == 1
+    @test floor(Int, [1, 1]) == [1, 1]
+    @test floor(Int, [1.1, 1.1]) == [1, 1]
+    @test floor(Int, [1 1]) == [1 1]
+    @test floor(Int, [1.1 1.1]) == [1 1]
+    @test floor(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
+    @test trunc(Int, 1) == 1
+    @test trunc(Int, 1.1) == 1
+    @test trunc(Int, [1, 1]) == [1, 1]
+    @test trunc(Int, [1.1, 1.1]) == [1, 1]
+    @test trunc(Int, [1 1]) == [1 1]
+    @test trunc(Int, [1.1 1.1]) == [1 1]
+    @test trunc(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
+end
 
 # n % Type
 for T in Any[Int16, Int32, UInt32, Int64, UInt64]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,31 +98,32 @@ if VERSION < v"0.4.0-dev+1387"
     @test isdefined(Main, :AbstractString)
 end
 
-if VERSION < v"0.6.0-"
-    @test round(Int, 3//4) == 1
-    @test round(Int, 1) == 1
-    @test round(Int, 1.1) == 1
+@test round(Int, 3//4) == 1
+@test round(Int, 1) == 1
+@test round(Int, 1.1) == 1
+@test ceil(Int, 1) == 1
+@test ceil(Int, 1.1) == 2
+@test floor(Int, 1) == 1
+@test floor(Int, 1.1) == 1
+@test trunc(Int, 1) == 1
+@test trunc(Int, 1.1) == 1
+
+if VERSION < v"0.6.0-dev.1825"
     @test round(Int, [1, 1]) == [1, 1]
     @test round(Int, [1.1, 1.1]) == [1, 1]
     @test round(Int, [1 1]) == [1 1]
     @test round(Int, [1.1 1.1]) == [1 1]
     @test round(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
-    @test ceil(Int, 1) == 1
-    @test ceil(Int, 1.1) == 2
     @test ceil(Int, [1, 1]) == [1, 1]
     @test ceil(Int, [1.1, 1.1]) == [2, 2]
     @test ceil(Int, [1 1]) == [1 1]
     @test ceil(Int, [1.1 1.1]) == [2 2]
     @test ceil(Int, fill(1.1, 2, 3, 4)) == fill(2, 2, 3, 4)
-    @test floor(Int, 1) == 1
-    @test floor(Int, 1.1) == 1
     @test floor(Int, [1, 1]) == [1, 1]
     @test floor(Int, [1.1, 1.1]) == [1, 1]
     @test floor(Int, [1 1]) == [1 1]
     @test floor(Int, [1.1 1.1]) == [1 1]
     @test floor(Int, fill(1.1, 2, 3, 4)) == fill(1, 2, 3, 4)
-    @test trunc(Int, 1) == 1
-    @test trunc(Int, 1.1) == 1
     @test trunc(Int, [1, 1]) == [1, 1]
     @test trunc(Int, [1.1, 1.1]) == [1, 1]
     @test trunc(Int, [1 1]) == [1 1]
@@ -577,9 +578,6 @@ for T = (Float32, Float64)
     @test [Compat.linspace(-u,-u,1);] == [-u]
     @test [Compat.linspace(-u,u,2);] == [-u,u]
     @test [Compat.linspace(-u,u,3);] == [-u,0,u]
-    @test [Compat.linspace(-u,u,4);] == [-u,0,0,u]
-    @test [Compat.linspace(-u,u,4);][2] === -z
-    @test [Compat.linspace(-u,u,4);][3] === z
     @test first(Compat.linspace(-u,-u,0)) == -u
     @test last(Compat.linspace(-u,-u,0)) == -u
     @test first(Compat.linspace(u,-u,0)) == u
@@ -588,12 +586,8 @@ for T = (Float32, Float64)
     @test [Compat.linspace(u,u,1);] == [u]
     @test [Compat.linspace(u,-u,2);] == [u,-u]
     @test [Compat.linspace(u,-u,3);] == [u,0,-u]
-    @test [Compat.linspace(u,-u,4);] == [u,0,0,-u]
-    @test [Compat.linspace(u,-u,4);][2] === z
-    @test [Compat.linspace(u,-u,4);][3] === -z
     v = [Compat.linspace(-u,u,12);]
     @test length(v) == 12
-    @test issorted(v) && unique(v) == [-u,0,0,u]
     @test [-3u:u:3u;] == [Compat.linspace(-3u,3u,7);] == [-3:3;].*u
     @test [3u:-u:-3u;] == [Compat.linspace(3u,-3u,7);] == [3:-1:-3;].*u
 end
@@ -1336,8 +1330,10 @@ end
 @test allunique([1, 2, 3])
 @test !allunique([1, 2, 1])
 @test allunique(1:3)
-@test allunique(FloatRange(0.0, 0.0, 0.0, 1.0))
-@test !allunique(FloatRange(0.0, 0.0, 2.0, 1.0))
+if VERSION < v"0.6.0-dev.2390"
+    @test allunique(FloatRange(0.0, 0.0, 0.0, 1.0))
+    @test !allunique(FloatRange(0.0, 0.0, 2.0, 1.0))
+end
 
 # Add test for Base.view
 let a = rand(10,10)


### PR DESCRIPTION
Since `walkdir` returns a `Task` in 0.5 and a `Channel` in 0.6 the implementation in Compat would need to be updated. For now, I've done this by not exporting the `Compat` version such that you'd have to use `Compat.walkdir` instead of just `walkdir`.

`promote_eltype_op` is now deprecated on master so I've also deprecated the `Compat` version.

Testing of vectorized `round`, `ceil`, `floor`, and `trunc` is disabled on 0.6 since the dot syntax should be used.

Some minor syntax deprecations.