### PR TITLE
at-compat for Foo{<:Bar} sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Currently, the `@compat` macro supports the following syntaxes:
   includes expressions with lower precedence than `==` you should enclose it in parentheses `x .= (y)` to ensure the
   correct order of evaluation.
 
+* `@compat Array{<:Real}` and similar uses of `<:T` to define a set of parameterized types ([#20414]).
+  In 0.4 and 0.5, this only works for non-nested usages (e.g. you can't define `Array{<:Array{<:Real}}`).
+
 ## Type Aliases
 
 * In 0.5, `ASCIIString` and `ByteString` were deprecated, and `UTF8String` was renamed to the (now concrete) type `String`.
@@ -278,10 +281,14 @@ includes this fix. Find the minimum version from there.
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
 [#17510]: https://github.com/JuliaLang/julia/issues/17510
+[#17623]: https://github.com/JuliaLang/julia/issues/17623
 [#18380]: https://github.com/JuliaLang/julia/issues/18380
 [#18484]: https://github.com/JuliaLang/julia/issues/18484
 [#18510]: https://github.com/JuliaLang/julia/issues/18510
 [#18977]: https://github.com/JuliaLang/julia/issues/18977
 [#19088]: https://github.com/JuliaLang/julia/issues/19088
 [#19246]: https://github.com/JuliaLang/julia/issues/19246
+[#19841]: https://github.com/JuliaLang/julia/issues/19841
 [#19950]: https://github.com/JuliaLang/julia/issues/19950
+[#20022]: https://github.com/JuliaLang/julia/issues/20022
+[#20414]: https://github.com/JuliaLang/julia/issues/20414

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -638,14 +638,12 @@ function _compat(ex::Expr)
         elseif VERSION < v"0.4.0-dev+5379" && f === :Union
             ex = Expr(:call,:Union,ex.args[2:end]...)
         elseif ex == :(Ptr{Void})
-            # Do no change Ptr{Void} to Ptr{Nothing}: 0.4.0-dev+768
+            # Do not change Ptr{Void} to Ptr{Nothing}: 0.4.0-dev+768
             return ex
         elseif VERSION < v"0.6.0-dev.2575" #20414
-            for i = 2:length(ex.args)
-                if isexpr(ex.args[i], :call, 2) && ex.args[i].args[1] == :(<:)
-                    ex.args[i] = :($TypeVar($(QuoteNode(gensym(:T))), $(ex.args[i].args[2]), false))
-                end
-            end
+            ex = Expr(:curly, map(a -> isexpr(a, :call, 2) && a.args[1] == :(<:) ?
+                                  :($TypeVar($(QuoteNode(gensym(:T))), $(a.args[2]), false)) : a,
+                                  ex.args)...)
         end
     elseif ex.head === :macrocall
         f = ex.args[1]

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -640,6 +640,12 @@ function _compat(ex::Expr)
         elseif ex == :(Ptr{Void})
             # Do no change Ptr{Void} to Ptr{Nothing}: 0.4.0-dev+768
             return ex
+        elseif VERSION < v"0.6.0-dev.2575" #20414
+            for i = 2:length(ex.args)
+                if isexpr(ex.args[i], :call, 2) && ex.args[i].args[1] == :(<:)
+                    ex.args[i] = :($TypeVar($(QuoteNode(gensym(:T))), $(ex.args[i].args[2]), false))
+                end
+            end
         end
     elseif ex.head === :macrocall
         f = ex.args[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1532,6 +1532,13 @@ end
 @test xor(1,5) == 4
 @test 1 ⊻ 5 == 4
 
+# julia#20414
+@compat let T = Array{<:Real}, f(x::AbstractVector{<:Real}) = 1
+    @test isa([3,4],T)
+    @test !isa([3,4im],T)
+    @test f(1:3) == f([1,2]) == 1
+end
+
 # julia#19246
 @test numerator(1//2) === 1
 @test denominator(1//2) === 2


### PR DESCRIPTION
`@compat` support for https://github.com/JuliaLang/julia/pull/20414 (at least for non-nested cases that are possible to support).  