### PR TITLE
Fix version check for .& and .|

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1757,7 +1757,7 @@ if VERSION < v"0.5.0-dev+3669"
         scale!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), D.diag, A)
 end
 
-if VERSION >= v"0.5.0-dev+5509" && VERSION < v"0.6.0-dev.1614"
+if VERSION >= v"0.5.0-dev+5509" && VERSION < v"0.6.0-dev.1632"
     # To work around unsupported syntax on Julia 0.4
     include_string("export .&, .|")
     include_string(".&(xs...) = broadcast(&, xs...)")


### PR DESCRIPTION
Point to the merge commit instead of the individual commit which
introduced the feature.

Cf. https://github.com/JuliaLang/Compat.jl/pull/306#discussion_r99460210.