### PR TITLE
Add Compat.readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.isapprox` with `nans` keyword argument ([#20022])
 
+* `Compat.readline` with `chomp` keyword argument ([#20203])
+
 * `take!` method for `Task`s since some functions now return `Channel`s instead of `Task`s ([#19841])
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
@@ -336,6 +338,7 @@ includes this fix. Find the minimum version from there.
 [#19950]: https://github.com/JuliaLang/julia/issues/19950
 [#20022]: https://github.com/JuliaLang/julia/issues/20022
 [#20164]: https://github.com/JuliaLang/julia/issues/20164
+[#20203]: https://github.com/JuliaLang/julia/issues/20203
 [#20321]: https://github.com/JuliaLang/julia/issues/20321
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
 [#20418]: https://github.com/JuliaLang/julia/issues/20418

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -597,8 +597,8 @@ if VERSION < v"0.5.0-dev+2228"
     Base.read(filename::AbstractString, args...) = open(io->read(io, args...), filename)
     Base.read!(filename::AbstractString, a) = open(io->read!(io, a), filename)
     Base.readuntil(filename::AbstractString, args...) = open(io->readuntil(io, args...), filename)
-    Base.readline(filename::AbstractString) = open(readline, filename)
-    Base.readlines(filename::AbstractString) = open(readlines, filename)
+    Base.readline(filename::AbstractString) = open(Base.readline, filename)
+    Base.readlines(filename::AbstractString) = open(Base.readlines, filename)
     Base.readavailable(s::IOStream) = read!(s, @compat Vector{UInt8}(nb_available(s)))
     Base.readavailable(s::IOBuffer) = read(s)
 
@@ -1409,6 +1409,18 @@ if VERSION < v"0.6.0-dev.2840"
     eval(Expr(:typealias, :IndexCartesian, :(Base.LinearSlow)))
     IndexStyle{T}(::Type{T}) = Base.linearindexing(T)
     IndexStyle(args...) = Base.linearindexing(args...)
+end
+
+# https://github.com/JuliaLang/julia/pull/20203
+if VERSION < v"0.6.0-dev.2283"
+    # not exported
+    function readline(s::IO=STDIN; chomp::Bool=true)
+        if chomp
+            Base.chomp(Base.readline(s))
+        else
+            Base.readline(s)
+        end
+    end
 end
 
 include("to-be-deprecated.jl")

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1416,7 +1416,7 @@ if VERSION < v"0.6.0-dev.2283"
     # not exported
     function readline(s::IO=STDIN; chomp::Bool=true)
         if chomp
-            Base.chomp(Base.readline(s))
+            Base.chomp!(Base.readline(s))
         else
             Base.readline(s)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1763,4 +1763,9 @@ let a = CompatArray.CartesianArray(rand(2,3)), b = CompatArray.LinearArray(rand(
     @test IndexStyle(b) === IndexLinear()
 end
 
+# PR 20203
+@test Compat.readline(IOBuffer("Hello, World!\n")) == "Hello, World!"
+@test Compat.readline(IOBuffer("x\n"), chomp=true) == "x"
+@test Compat.readline(IOBuffer("x\n"), chomp=false) == "x\n"
+
 include("to-be-deprecated.jl")


### PR DESCRIPTION
Fix #333.

`eachline` and `readlines` are significantly harder to do properly. We would either need to implement a lazy iterator map, or port the functions to `Compat`. I think we should add this first and leave those until someone wants them.