### PR TITLE
Add `>:`:

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `∘` (typically used infix as `f ∘ g`) for function composition can be used in 0.5 and earlier ([#17155])
 
-* `>:`, a supertype operator, for symmetry with `issubtype` (`A >: B` is equivalent to `B <: A`) ([#20407])
+* `>:`, a supertype operator for symmetry with `issubtype` (`A >: B` is equivalent to `B <: A`), can be used in 0.5 and earlier ([#20407]).
 
 * The method of `!` to negate functions (typically used as a unary operator, as in `!isinteger`) can be used in 0.5 and earlier ([#17155]).
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Currently, the `@compat` macro supports the following syntaxes:
   correct order of evaluation.   Also, `x .+= y` converts to `x .= (x .+ y)`, and similarly for the other updating
   assignment operators (`.*=` and so on).
 
-* `@compat Array{<:Real}` and similar uses of `<:T` to define a set of parameterized types ([#20414]).
+* `@compat Array{<:Real}`, `@compat Array{>:Int}`, and similar uses of `<:T` (resp. `>:T`) to define a set of "covariant" (resp. "contravariant") parameterized types ([#20414]).
   In 0.4 and 0.5, this only works for non-nested usages (e.g. you can't define `Array{<:Array{<:Real}}`).
 
 * `@compat abstract type T end` and `@compat primitive type T 8 end`
@@ -134,6 +134,8 @@ Currently, the `@compat` macro supports the following syntaxes:
    alternative to the LegacyStrings package) ([#17323])
 
 * `∘` (typically used infix as `f ∘ g`) for function composition can be used in 0.5 and earlier ([#17155])
+
+* `>:`, a supertype operator, for symmetry with `issubtype` (`A >: B` is equivalent to `B <: A`) ([#20407])
 
 * The method of `!` to negate functions (typically used as a unary operator, as in `!isinteger`) can be used in 0.5 and earlier ([#17155]).
 
@@ -340,6 +342,7 @@ includes this fix. Find the minimum version from there.
 [#20164]: https://github.com/JuliaLang/julia/issues/20164
 [#20203]: https://github.com/JuliaLang/julia/issues/20203
 [#20321]: https://github.com/JuliaLang/julia/issues/20321
+[#20407]: https://github.com/JuliaLang/julia/issues/20407
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
 [#20418]: https://github.com/JuliaLang/julia/issues/20418
 [#20500]: https://github.com/JuliaLang/julia/issues/20500

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1159,7 +1159,9 @@ end
 
 # julia　#20407
 if !isdefined(Base, :(>:))
-    (>:)(a::ANY, b::ANY) = issubtype(b, a)
+    const >: = let
+        _issupertype(a::ANY, b::ANY) = issubtype(b, a)
+    end
     export >:
 end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -384,7 +384,9 @@ function _compat(ex::Expr)
             return ex
         elseif VERSION < v"0.6.0-dev.2575" #20414
             ex = Expr(:curly, map(a -> isexpr(a, :call, 2) && a.args[1] == :(<:) ?
-                                  :($TypeVar($(QuoteNode(gensym(:T))), $(a.args[2]), false)) : a,
+                                  :($TypeVar($(QuoteNode(gensym(:T))), $(a.args[2]), false)) :
+                                  isexpr(a, :call, 2) && a.args[1] == :(>:) ?
+                                  :($TypeVar($(QuoteNode(gensym(:T))), $(a.args[2]), $Any, false)) : a,
                                   ex.args)...)
         end
     elseif ex.head === :macrocall
@@ -1153,6 +1155,12 @@ if !isdefined(Base, :iszero)
     iszero(x::Number) = x == 0
     iszero(x::AbstractArray) = all(iszero, x)
     export iszero
+end
+
+# julia　#20407
+if !isdefined(Base, :(>:))
+    (>:)(a::ANY, b::ANY) = issubtype(b, a)
+    export >:
 end
 
 # julia#19088

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1490,6 +1490,16 @@ end
     @test !isa([3,4im],T)
     @test f(1:3) == f([1,2]) == 1
 end
+@compat let T = Array{>:Integer}, f(x::AbstractVector{>:Integer}) = 1
+    @test isa(Integer[1,2],T)
+    @test !isa([3,4],T)
+    @test !isa([3.0,4.0],T)
+    @test f(Integer[1,2]) == f([1,'a',:sym]) == 1
+end
+
+# supertype operator
+@test !(Int >: Integer)
+@test Integer >: Int
 
 # julia#19246
 @test numerator(1//2) === 1


### PR DESCRIPTION
* Support `Type{>:AnotherType}` notation.
* Define `A >: B` operator as `B <: A`

What do you think about this?
(I know that there is not much demand, but I want it personally)