### PR TITLE
Type definition macros for 0.5-1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Currently, the `@compat` macro supports the following syntaxes:
   vectorized function have migrated. These macros will be dropped when the
   support for `0.6` is dropped from `Compat`.
 
+* `@struct begin ... end` is equivalent to `immutable ... end` in Julia 0.5 and `struct ... end` in Julia 0.6+. `@mutable_struct begin ... end` is equivalent to `type ... end` in Julia 0.5 and `mutable struct ... end` in Julia 0.6+.
+
 ## Other changes
 
 * `remotecall`, `remotecall_fetch`, `remotecall_wait`, and `remote_do` have the function to be executed remotely as the first argument in Julia 0.5. Loading `Compat` defines the same methods in older versions of Julia ([#13338])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1768,4 +1768,28 @@ end
 @test Compat.readline(IOBuffer("x\n"), chomp=true) == "x"
 @test Compat.readline(IOBuffer("x\n"), chomp=false) == "x\n"
 
+# PR 20418
+@mutable_struct begin MutableTestType{T<:Real} <: Real
+    x::T
+
+    MutableTestType() = new(one(T))
+end
+@test isdefined(:MutableTestType)
+@test isa(MutableTestType, Type)
+@test fieldnames(MutableTestType) == [:x]
+@test fieldtype(MutableTestType{Int}, :x) === Int
+@test fieldtype(MutableTestType{Integer}, :x) === Integer
+@test !isimmutable(MutableTestType{Int}())
+@immutable_struct begin ImmutableTestType{T<:Real} <: Real
+    x::T
+
+    ImmutableTestType() = new(one(T))
+end
+@test isdefined(:ImmutableTestType)
+@test isa(ImmutableTestType, Type)
+@test fieldnames(ImmutableTestType) == [:x]
+@test fieldtype(ImmutableTestType{Int}, :x) === Int
+@test fieldtype(ImmutableTestType{Integer}, :x) === Integer
+@test isimmutable(ImmutableTestType{Int}())
+
 include("to-be-deprecated.jl")


### PR DESCRIPTION
This allows you to write type definitions that work on 0.5 and 1.0. Not sure if this is actually desired but I wrote it.