### PR TITLE
Backport Set conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `zeros` and `ones` support an interface the same as `similar` ([#19635])
 
+* `convert` can convert between different `Set` types on 0.5 and below. ([#18727])
+
 ## Renamed functions
 
 * `pointer_to_array` and `pointer_to_string` have been replaced with `unsafe_wrap(Array, ...)` and `unsafe_wrap(String, ...)` respectively
@@ -334,10 +336,12 @@ includes this fix. Find the minimum version from there.
 [#18380]: https://github.com/JuliaLang/julia/issues/18380
 [#18484]: https://github.com/JuliaLang/julia/issues/18484
 [#18510]: https://github.com/JuliaLang/julia/issues/18510
+[#18727]: https://github.com/JuliaLang/julia/issues/18727
 [#18839]: https://github.com/JuliaLang/julia/issues/18839
 [#18977]: https://github.com/JuliaLang/julia/issues/18977
 [#19088]: https://github.com/JuliaLang/julia/issues/19088
 [#19246]: https://github.com/JuliaLang/julia/issues/19246
+[#19635]: https://github.com/JuliaLang/julia/issues/19635
 [#19841]: https://github.com/JuliaLang/julia/issues/19841
 [#19950]: https://github.com/JuliaLang/julia/issues/19950
 [#20022]: https://github.com/JuliaLang/julia/issues/20022
@@ -348,4 +352,3 @@ includes this fix. Find the minimum version from there.
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
 [#20418]: https://github.com/JuliaLang/julia/issues/20418
 [#20500]: https://github.com/JuliaLang/julia/issues/20500
-[#19635]: https://github.com/JuliaLang/julia/issues/19635

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1447,7 +1447,7 @@ end
 # https://github.com/JuliaLang/julia/pull/18727
 if VERSION < v"0.6.0-dev.838"
     convert{T}(::Type{Set{T}}, s::Set{T}) = s
-    convert{T,S}(::Type{Set{T}}, x::Set{S}) = Set{T}(x)
+    convert{T}(::Type{Set{T}}, s::Set) = Set{T}(s)
 end
 
 include("to-be-deprecated.jl")

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1444,6 +1444,12 @@ if VERSION < v"0.6.0-dev.2283"
     end
 end
 
+# https://github.com/JuliaLang/julia/pull/18727
+if VERSION < v"0.6.0-dev.838"
+    convert{T}(::Type{Set{T}}, s::Set{T}) = s
+    convert{T,S}(::Type{Set{T}}, x::Set{S}) = Set{T}(x)
+end
+
 include("to-be-deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1446,8 +1446,8 @@ end
 
 # https://github.com/JuliaLang/julia/pull/18727
 if VERSION < v"0.6.0-dev.838"
-    convert{T}(::Type{Set{T}}, s::Set{T}) = s
-    convert{T}(::Type{Set{T}}, s::Set) = Set{T}(s)
+    Base.convert{T}(::Type{Set{T}}, s::Set{T}) = s
+    Base.convert{T}(::Type{Set{T}}, s::Set) = Set{T}(s)
 end
 
 include("to-be-deprecated.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1789,6 +1789,22 @@ end
 @test Compat.readline(IOBuffer("x\n"), chomp=true) == "x"
 @test Compat.readline(IOBuffer("x\n"), chomp=false) == "x\n"
 
+# PR 18727
+let
+    iset = Set([17, 4711])
+    cfset = convert(Set{Float64}, iset)
+    @test typeof(cfset) == Set{Float64}
+    @test cfset == iset
+    fset = Set([17.0, 4711.0])
+    ciset = convert(Set{Int}, fset)
+    @test typeof(ciset) == Set{Int}
+    @test ciset == fset
+    ssset = Set(split("foo bar"))
+    cssset = convert(Set{String}, ssset)
+    @test typeof(cssset) == Set{String}
+    @test cssset == Set(["foo", "bar"])
+end
+
 include("to-be-deprecated.jl")
 
 nothing


### PR DESCRIPTION
From https://github.com/JuliaLang/julia/pull/18727, backport the inter-Set conversions to 0.5 and below.