### PR TITLE
Backport bswap method for complex numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `unsafe_trunc(::Type{<:Integer}, ::Integer)` is supported on 0.5. ([#18629])
 
+* `bswap` is supported for `Complex` arguments. ([#21346])
+
 ## Renamed functions
 
 * `pointer_to_array` and `pointer_to_string` have been replaced with `unsafe_wrap(Array, ...)` and `unsafe_wrap(String, ...)` respectively
@@ -358,3 +360,4 @@ includes this fix. Find the minimum version from there.
 [#20418]: https://github.com/JuliaLang/julia/issues/20418
 [#20500]: https://github.com/JuliaLang/julia/issues/20500
 [#18629]: https://github.com/JuliaLang/julia/pull/18629
+[#21346]: https://github.com/JuliaLang/julia/pull/21346

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `unsafe_trunc(::Type{<:Integer}, ::Integer)` is supported on 0.5. ([#18629])
 
-* `bswap` is supported for `Complex` arguments. ([#21346])
+* `bswap` is supported for `Complex` arguments on 0.5 and below. ([#21346])
 
 ## Renamed functions
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1459,6 +1459,11 @@ if VERSION < v"0.6.0-dev.735"
     Base.unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
 end
 
+# https://github.com/JuliaLang/julia/pull/21346
+if VERSION < v"0.6.0-pre.beta.102"
+    Base.bswap(z::Complex) = Complex(bswap(real(z)), bswap(imag(z)))
+end
+
 include("to-be-deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1812,6 +1812,16 @@ end
 @test unsafe_trunc(Int8, 128) === Int8(-128)
 @test_throws InexactError trunc(Int8, 128)
 
+# PR 21346
+let zbuf = IOBuffer([0xbf, 0xc0, 0x00, 0x00, 0x40, 0x20, 0x00, 0x00,
+                     0x40, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                     0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    z1 = read(zbuf, Complex64)
+    z2 = read(zbuf, Complex128)
+    @test bswap(z1) === -1.5f0 + 2.5f0im
+    @test bswap(z2) ===  3.5 - 4.5im
+end
+
 include("to-be-deprecated.jl")
 
 nothing


### PR DESCRIPTION
It was added to julia in [PR#21346](https://github.com/JuliaLang/julia/pull/21346), commit [b7836db](https://github.com/JuliaLang/julia/commit/b7836db4527e07a07d2415a8780294e9067a1f97).

Originally I had this method in my own package [FortranFiles.jl](https://github.com/traktofon/FortranFiles.jl) (which also supports julia 0.5), but because this defines a Base method for a Base datatype, @tkelman suggested it might go into Base, and if accepted there, also into Compat.