### PR TITLE
Compat flag for adding source location argument to macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ for `HermOrSym` such that using the new methods are backward compatible.
 
 * Single-argument `min`, `max` and `minmax` are defined on 0.4.
 
+* The `Expr(:macrocall)` has an extra initial argument `__source__`, which can be tested for with `Compat.macros_have_sourceloc`.
+
 ## New types
 
 Currently, no new exported types are introduced by Compat.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1494,4 +1494,7 @@ end
 
 include("to-be-deprecated.jl")
 
+# https://github.com/JuliaLang/julia/pull/21746
+const macros_have_sourceloc = VERSION >= v"0.7-" && length(:(@test).args) == 2
+
 end # module Compat


### PR DESCRIPTION
This is needed for JuliaLang/julia#21746 to pass CI, so I can't have an exact commit number and instead am providing this boolean flag for packages to use as a feature test.