### PR TITLE
Changes invokelatest eval to run in current_module()

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1475,7 +1475,7 @@ end
 if isdefined(Base, :invokelatest)
     import Base.invokelatest
 else
-    invokelatest(f, args...) = eval(Expr(:call, f, map(QuoteNode, args)...))
+    invokelatest(f, args...) = eval(current_module(), Expr(:call, f, map(QuoteNode, args)...))
 end
 
 # https://github.com/JuliaLang/julia/pull/21257

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1848,6 +1848,7 @@ let foo() = begin
     end
     @test foo() == 2
 end
+@test Compat.invokelatest(current_module) === current_module()
 
 # PR 21378
 let


### PR DESCRIPTION
`invokelatest` runs in module Compat on julia 0.5, so this:
```
import Compat.invokelatest
invokelatest(current_module)
```
returns `Compat` in julia 0.5, but on 0.6-rc1.0 (which has `Base.invokelatest` defined) it returns `Main`.

After this PR they both return `Main`.