### PR TITLE
WIP: Dropping 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
     - 0.5
     - 0.6
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -7,48 +7,6 @@ using Base.Meta
 """Get just the function part of a function declaration."""
 withincurly(ex) = isexpr(ex, :curly) ? ex.args[1] : ex
 
-if VERSION < v"0.5.0-dev+961"
-    export walkdir
-
-    function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
-        content = nothing
-        try
-            content = readdir(root)
-        catch err
-            isa(err, SystemError) || throw(err)
-            onerror(err)
-            #Need to return an empty task to skip the current root folder
-            return Task(()->())
-        end
-        dirs = Array(eltype(content), 0)
-        files = Array(eltype(content), 0)
-        for name in content
-            if isdir(joinpath(root, name))
-                push!(dirs, name)
-            else
-                push!(files, name)
-            end
-        end
-
-        function _it()
-            if topdown
-                produce(root, dirs, files)
-            end
-            for dir in dirs
-                path = joinpath(root,dir)
-                if follow_symlinks || !islink(path)
-                    for (root_l, dirs_l, files_l) in walkdir(path, topdown=topdown, follow_symlinks=follow_symlinks, onerror=onerror)
-                        produce(root_l, dirs_l, files_l)
-                    end
-                end
-            end
-            if !topdown
-                produce(root, dirs, files)
-            end
-        end
-        Task(_it)
-    end
-end
 if VERSION < v"0.6.0-dev.2043"
     Base.take!(t::Task) = consume(t)
 end
@@ -94,36 +52,6 @@ function rewrite_ordereddict(ex)
     end
 
     newex
-end
-
-# rewrite Julia 0.4-style split or rsplit (str, splitter; kws...)
-# into 0.2/0.3-style positional arguments
-function rewrite_split(ex, f)
-    limit = nothing
-    keep = nothing
-    for i in 4:length(ex.args)
-        if isexpr(ex.args[i], :kw)
-            kw = ex.args[i].args
-            if kw[1] == :limit
-                limit = kw[2]
-            elseif kw[1] == :keep
-                keep = kw[2]
-            end
-        end
-    end
-    if limit == nothing
-        if keep == nothing
-            return Expr(:call, f, ex.args[2], ex.args[3])
-        else
-            return Expr(:call, f, ex.args[2], ex.args[3], keep)
-        end
-    else
-        if keep == nothing
-            return Expr(:call, f, ex.args[2], ex.args[3], limit)
-        else
-            return Expr(:call, f, ex.args[2], ex.args[3], limit, keep)
-        end
-    end
 end
 
 # rewrites all subexpressions of the form `a => b` to `(a, b)`
@@ -191,168 +119,7 @@ end
 
 import Base.unsafe_convert
 
-if VERSION < v"0.5.0-dev+3831"
-    Base.Symbol(args...) = symbol(args...)::Symbol
-end
-
-if VERSION < v"0.5.0-dev+2396"
-    function new_style_call_overload(ex::Expr)
-        # Not a function call
-        ((ex.head === :(=) || ex.head === :function) &&
-         length(ex.args) == 2 && isexpr(ex.args[1], :call)) || return false
-        callee = (ex.args[1]::Expr).args[1]
-        # Only Expr function name can be call overload
-        isa(callee, Expr) || return false
-        callee = callee::Expr
-        # (a::A)() = ...
-        callee.head === :(::) && return true
-        # The other case is with type parameter.
-        # Filter out everything without one.
-        (callee.head === :curly && length(callee.args) >= 1) || return false
-        # Check what the type parameter applies to is a Expr(:(::))
-        return isexpr(callee.args[1], :(::))
-    end
-else
-    new_style_call_overload(ex::Expr) = false
-end
-
 istopsymbol(ex, mod, sym) = ex in (sym, Expr(:(.), mod, Expr(:quote, sym)))
-
-if VERSION < v"0.5.0-dev+4002"
-    @inline broadcast_getindex(arg, idx) = arg[(idx - 1) % length(arg) + 1]
-    # Optimize for single element
-    @inline broadcast_getindex(arg::Number, idx) = arg
-    @inline broadcast_getindex{T}(arg::Array{T,0}, idx) = arg[1]
-
-    # If we know from syntax level that we don't need wrapping
-    @inline broadcast_getindex_naive(arg, idx) = arg[idx]
-    @inline broadcast_getindex_naive(arg::Number, idx) = arg
-    @inline broadcast_getindex_naive{T}(arg::Array{T,0}, idx) = arg[1]
-
-    # For vararg support
-    @inline getindex_vararg(idx) = ()
-    @inline getindex_vararg(idx, arg1) = (broadcast_getindex(arg1, idx),)
-    @inline getindex_vararg(idx, arg1, arg2) =
-        (broadcast_getindex(arg1, idx), broadcast_getindex(arg2, idx))
-    @inline getindex_vararg(idx, arg1, arg2, arg3, args...) =
-        (broadcast_getindex(arg1, idx), broadcast_getindex(arg2, idx),
-         broadcast_getindex(arg3, idx), getindex_vararg(idx, args...)...)
-
-    @inline getindex_naive_vararg(idx) = ()
-    @inline getindex_naive_vararg(idx, arg1) =
-        (broadcast_getindex_naive(arg1, idx),)
-    @inline getindex_naive_vararg(idx, arg1, arg2) =
-        (broadcast_getindex_naive(arg1, idx),
-         broadcast_getindex_naive(arg2, idx))
-    @inline getindex_naive_vararg(idx, arg1, arg2, arg3, args...) =
-        (broadcast_getindex_naive(arg1, idx),
-         broadcast_getindex_naive(arg2, idx),
-         broadcast_getindex_naive(arg3, idx),
-         getindex_naive_vararg(idx, args...)...)
-
-    # Decide if the result should be scalar or array
-    # `size() === ()` is not good enough since broadcasting on
-    # a scalar should return a scalar where as broadcasting on a 0-dim
-    # array should return a 0-dim array.
-    @inline should_return_array(::Val{true}, args...) = Val{true}()
-    @inline should_return_array(::Val{false}) = Val{false}()
-    @inline should_return_array(::Val{false}, arg1) = Val{false}()
-    @inline should_return_array(::Val{false}, arg1::AbstractArray) = Val{true}()
-    @inline should_return_array(::Val{false}, arg1::AbstractArray,
-                                arg2::AbstractArray) = Val{true}()
-    @inline should_return_array(::Val{false}, arg1,
-                                arg2::AbstractArray) = Val{true}()
-    @inline should_return_array(::Val{false}, arg1::AbstractArray,
-                                arg2) = Val{true}()
-    @inline should_return_array(::Val{false}, arg1, arg2) = Val{false}()
-    @inline should_return_array(::Val{false}, arg1, arg2, args...) =
-        should_return_array(should_return_array(Val{false}(), arg1, arg2),
-                            args...)
-
-    @inline broadcast_return(res1d, shp, ret_ary::Val{false}) = res1d[1]
-    @inline broadcast_return(res1d, shp, ret_ary::Val{true}) = reshape(res1d, shp)
-
-    @inline need_full_getindex(shp) = false
-    @inline need_full_getindex(shp, arg1::Number) = false
-    @inline need_full_getindex{T}(shp, arg1::Array{T,0}) = false
-    @inline need_full_getindex(shp, arg1) = shp != size(arg1)
-    @inline need_full_getindex(shp, arg1, arg2) =
-        need_full_getindex(shp, arg1) || need_full_getindex(shp, arg2)
-    @inline need_full_getindex(shp, arg1, arg2, arg3, args...) =
-        need_full_getindex(shp, arg1, arg2) || need_full_getindex(shp, arg3) ||
-        need_full_getindex(shp, args...)
-
-    function rewrite_broadcast(f, args)
-        nargs = length(args)
-        # This actually allows multiple splatting...,
-        # which is now allowed on master.
-        # The previous version that simply calls broadcast so removing that
-        # will be breaking. Oh, well....
-        is_vararg = Bool[isexpr(args[i], :...) for i in 1:nargs]
-        names = [gensym("broadcast") for i in 1:nargs]
-        new_args = [is_vararg[i] ? Expr(:..., names[i]) : names[i]
-                    for i in 1:nargs]
-        # Optimize for common case where we know the index doesn't need
-        # any wrapping
-        naive_getidx_for = function (i, idxvar)
-            if is_vararg[i]
-                Expr(:..., :($Compat.getindex_naive_vararg($idxvar,
-                                                           $(names[i])...)))
-            else
-                :($Compat.broadcast_getindex_naive($(names[i]), $idxvar))
-            end
-        end
-        always_naive = nargs == 1 && !is_vararg[1]
-        getidx_for = if always_naive
-            naive_getidx_for
-        else
-            function (i, idxvar)
-                if is_vararg[i]
-                    Expr(:..., :($Compat.getindex_vararg($idxvar,
-                                                         $(names[i])...)))
-                else
-                    :($Compat.broadcast_getindex($(names[i]), $idxvar))
-                end
-            end
-        end
-        @gensym allidx
-        @gensym newshape
-        @gensym res1d
-        @gensym idx
-        @gensym ret_ary
-
-        res1d_expr = quote
-            $res1d = [$f($([naive_getidx_for(i, idx) for i in 1:nargs]...))
-                      for $idx in $allidx]
-        end
-        if !always_naive
-            res1d_expr = quote
-                if $Compat.need_full_getindex($newshape, $(new_args...))
-                    $res1d = [$f($([getidx_for(i, idx) for i in 1:nargs]...))
-                              for $idx in $allidx]
-                else
-                    $res1d_expr
-                end
-            end
-        end
-
-        return quote
-            # The `local` makes sure type inference can infer the type even
-            # in global scope as long as the input is type stable
-            local $(names...)
-            $([:($(names[i]) = $(is_vararg[i] ? args[i].args[1] : args[i]))
-               for i in 1:nargs]...)
-            local $newshape = $(Base.Broadcast).broadcast_shape($(new_args...))
-            # `eachindex` is not generic enough
-            local $allidx = 1:prod($newshape)
-            local $ret_ary = $Compat.should_return_array(Val{false}(),
-                                                         $(new_args...))
-            local $res1d
-            $res1d_expr
-            $Compat.broadcast_return($res1d, $newshape, $ret_ary)
-        end
-    end
-end
 
 if VERSION < v"0.6.0-dev.2782"
     function new_style_typealias(ex::ANY)
@@ -367,15 +134,9 @@ end
 function _compat(ex::Expr)
     if ex.head === :call
         f = ex.args[1]
-        if VERSION < v"0.5.0-dev+4340" && length(ex.args) > 3 &&
-                istopsymbol(withincurly(ex.args[1]), :Base, :show)
-            ex = rewrite_show(ex)
-        elseif VERSION < v"0.6.0-dev.826" && length(ex.args) == 3 && # julia#18510
+        if VERSION < v"0.6.0-dev.826" && length(ex.args) == 3 && # julia#18510
                 istopsymbol(withincurly(ex.args[1]), :Base, :Nullable)
             ex = Expr(:call, f, ex.args[2], Expr(:call, :(Compat._Nullable_field2), ex.args[3]))
-        end
-        if VERSION < v"0.5.0-dev+4305"
-            rewrite_iocontext!(ex)
         end
     elseif ex.head === :curly
         f = ex.args[1]
@@ -391,12 +152,6 @@ function _compat(ex::Expr)
         end
     elseif ex.head === :macrocall
         f = ex.args[1]
-        if VERSION < v"0.5.0-dev+2129" && f === symbol("@boundscheck") && length(ex.args) == 2
-            # Handle 0.5 single argument @boundscheck syntax. (0.4 has a two
-            # arguments and a very diffferent meaning).  `nothing` is included
-            # so we have a consistent return type.
-            ex = :($(ex.args[2]); nothing)
-        end
     elseif ex.head === :quote && isa(ex.args[1], Symbol)
         # Passthrough
         return ex
@@ -424,52 +179,11 @@ function _compat(ex::Expr)
             callexpr.args[2] = params
             callexpr.args[3] = obj
         end
-    elseif VERSION < v"0.5.0-dev+4002" && ex.head == :. && length(ex.args) == 2 # 15032
-        if isexpr(ex.args[2], :quote) && isa(ex.args[2].args[1], QuoteNode)
-            # foo.:bar -> foo.(:bar) in older Julia
-            return Expr(ex.head, _compat(ex.args[1]), ex.args[2].args[1])
-        elseif isexpr(ex.args[2], :quote) && isexpr(ex.args[2].args[1], :quote) &&
-               isa(ex.args[2].args[1].args[1], Symbol)
-            # foo.:bar -> foo.(:bar) in older Julia
-            return Expr(ex.head, _compat(ex.args[1]), QuoteNode(ex.args[2].args[1].args[1]))
-        elseif isexpr(ex.args[2], :tuple)
-            # f.(arg1, arg2...) -> broadcast(f, arg1, arg2...)
-            return rewrite_broadcast(_compat(ex.args[1]),
-                                     map(_compat, ex.args[2].args))
-        elseif !isa(ex.args[2], QuoteNode) &&
-               !(isexpr(ex.args[2], :quote) && isa(ex.args[2].args[1], Symbol))
-            # f.(arg) -> broadcast(f, arg)
-            return rewrite_broadcast(_compat(ex.args[1]), [_compat(ex.args[2])])
-        end
     elseif new_style_typealias(ex)
         ex.head = :typealias
     elseif ex.head === :const && length(ex.args) == 1 && new_style_typealias(ex.args[1])
         ex = ex.args[1]::Expr
         ex.head = :typealias
-    elseif ex.head === :import
-        if VERSION < v"0.5.0-dev+4340" && length(ex.args) == 2 && ex.args[1] === :Base && ex.args[2] === :show
-            return quote
-                import Base.show
-                import Base.writemime
-            end
-        end
-    elseif VERSION < v"0.5.0-dev+5575" #17510
-        if isexpr(ex, :comparison)
-            if length(ex.args) == 3 && ex.args[2] == :.=
-                return :(Base.broadcast!(Base.identity, $(_compat(todotview(ex.args[1]))), $(_compat(ex.args[3]))))
-            elseif length(ex.args) > 3 && ex.args[2] == :.=
-                return :(Base.broadcast!(Base.identity, $(_compat(todotview(ex.args[1]))), $(_compat(Expr(:comparison, ex.args[3:end]...)))))
-            end
-        elseif ex.head == :.= && length(ex.args) == 2 # may arise in macro-constructed expressions
-            return :(Base.broadcast!(Base.identity, $(_compat(todotview(ex.args[1]))), $(_compat(ex.args[2]))))
-        end
-    end
-    if VERSION < v"0.5.0-dev+5575" #17510
-        # transform e.g. x .+= y into x .= x .+ y:
-        shead = string(ex.head)
-        if first(shead) == '.' && length(shead) > 2 && last(shead) == '=' && length(ex.args) == 2
-            return _compat(Expr(:comparison, ex.args[1], :.=, Expr(:call, Symbol(shead[1:end-1]), ex.args...)))
-        end
     end
     if VERSION < v"0.6.0-dev.2840"
         if ex.head == :(=) && isa(ex.args[1], Expr) && ex.args[1].head == :call
@@ -485,12 +199,7 @@ function _compat(ex::Expr)
     end
     return Expr(ex.head, map(_compat, ex.args)...)
 end
-function _compat(ex::Symbol)
-    if VERSION < v"0.5.0-dev+1343" && (ex == :Future || ex == :RemoteChannel)
-        return :RemoteRef
-    end
-    return ex
-end
+
 _compat(ex) = ex
 
 function _get_typebody(ex::Expr)
@@ -547,132 +256,7 @@ export @compat, @inline, @noinline
 import Base.@irrational
 
 import Base: remotecall, remotecall_fetch, remotecall_wait, remote_do
-if VERSION < v"0.5.0-dev+431"
-    for f in (:remotecall, :remotecall_fetch, :remotecall_wait, :remote_do)
-        @eval begin
-            ($f)(f::Function, w::Base.LocalProcess, args...)   = ($f)(w, f, args...)
-            ($f)(f::Function, w::Base.Worker, args...)         = ($f)(w, f, args...)
-            ($f)(f::Function, id::Integer, args...)            = ($f)(id, f, args...)
-        end
-    end
-end
 
-if VERSION < v"0.5.0-dev+763"
-    export SparseArrays
-    const SparseArrays = Base.SparseMatrix
-end
-
-if VERSION < v"0.5.0-dev+1229"
-    const Filesystem = Base.FS
-else
-    import Base.Filesystem
-end
-
-if VERSION < v"0.5.0-dev+1946"
-    const supertype = super
-    export supertype
-end
-
-if VERSION < v"0.5.0-dev+679"
-    import Base: cov, cor
-
-    cov(x::AbstractVector, corrected::Bool) = cov(x, corrected=corrected)
-    cov(X::AbstractMatrix, vardim::Integer) = cov(X, vardim=vardim)
-    cov(X::AbstractMatrix, vardim::Integer, corrected::Bool) = cov(X, vardim=vardim, corrected=corrected)
-    cov(x::AbstractVector, y::AbstractVector, corrected::Bool) = cov(x, y, corrected=corrected)
-    cov(X::AbstractMatrix, Y::AbstractMatrix, vardim::Integer) = cov(X, Y, vardim=vardim)
-    cov(X::AbstractMatrix, Y::AbstractMatrix, vardim::Integer, corrected::Bool) = cov(X, Y, vardim=vardim, corrected=corrected)
-
-    cor(X::AbstractMatrix, vardim::Integer) = cor(X, vardim=vardim)
-    cor(X::AbstractMatrix, Y::AbstractMatrix, vardim::Integer) = cor(X, Y, vardim=vardim)
-end
-
-if VERSION < v"0.5.0-dev+2228"
-    const readstring = readall
-    export readstring
-
-    Base.read(s::IO) = readbytes(s)
-    Base.read(s::IO, nb) = readbytes(s, nb)
-
-    Base.write(filename::AbstractString, args...) = open(io->write(io, args...), filename, "w")
-
-    Base.read(filename::AbstractString, args...) = open(io->read(io, args...), filename)
-    Base.read!(filename::AbstractString, a) = open(io->read!(io, a), filename)
-    Base.readuntil(filename::AbstractString, args...) = open(io->readuntil(io, args...), filename)
-    Base.readline(filename::AbstractString) = open(Base.readline, filename)
-    Base.readlines(filename::AbstractString) = open(Base.readlines, filename)
-    Base.readavailable(s::IOStream) = read!(s, @compat Vector{UInt8}(nb_available(s)))
-    Base.readavailable(s::IOBuffer) = read(s)
-
-    function Base.write(to::IO, from::IO)
-        while !eof(from)
-            write(to, readavailable(from))
-        end
-    end
-
-    function Base.eachline(filename::AbstractString)
-        s = open(filename)
-        EachLine(s, ()->close(s))
-    end
-end
-
-if VERSION < v"0.5.0-dev+2023"
-    const displaysize = Base.tty_size
-    export displaysize
-end
-
-
-# Pull Request https://github.com/JuliaLang/julia/pull/13232
-# Rounding and precision functions:
-
-if VERSION >= v"0.5.0-dev+1182"
-    import Base:
-        setprecision, setrounding, rounding
-
-else  # if VERSION < v"0.5.0-dev+1182"
-
-    export setprecision
-    export setrounding
-    export rounding
-
-    setprecision(f, ::Type{BigFloat}, prec) = with_bigfloat_precision(f, prec)
-    setprecision(::Type{BigFloat}, prec) = set_bigfloat_precision(prec)
-
-    # assume BigFloat if type not explicit:
-    setprecision(prec) = setprecision(BigFloat, prec)
-    setprecision(f, prec) = setprecision(f, BigFloat, prec)
-
-    Base.precision(::Type{BigFloat}) = get_bigfloat_precision()
-
-    setrounding(f, T, rounding_mode) =
-        with_rounding(f, T, rounding_mode)
-
-    setrounding(T, rounding_mode) = set_rounding(T, rounding_mode)
-
-    rounding(T) = get_rounding(T)
-
-end
-
-module LinAlg
-    if VERSION < v"0.5.0-dev+2022"
-        const checksquare = Base.LinAlg.chksquare
-    else
-        import Base.LinAlg.checksquare
-    end
-end
-
-if VERSION < v"0.5.0-dev+2915"
-    const issymmetric = issym
-    export issymmetric
-end
-
-if VERSION < v"0.5.0-dev+977"
-    export foreach
-
-    foreach(f) = (f(); nothing)
-    foreach(f, itr) = (for x in itr; f(x); end; nothing)
-    foreach(f, itrs...) = (for z in zip(itrs...); f(z...); end; nothing)
-end
 
 if !isdefined(Base, :istextmime)
     export istextmime
@@ -690,79 +274,10 @@ end
 
 export @functorize
 macro functorize(f)
-    if VERSION >= v"0.5.0-dev+3701"
-        f === :scalarmax       ? :(Base.scalarmax) :
-        f === :scalarmin       ? :(Base.scalarmin) :
-        f === :centralizedabs2fun ? :(primarytype(typeof(Base.centralizedabs2fun(0)))) :
-        f
-    else
-        f = f === :identity        ? :(Base.IdFun()) :
-            f === :abs             ? :(Base.AbsFun()) :
-            f === :abs2            ? :(Base.Abs2Fun()) :
-            f === :exp             ? :(Base.ExpFun()) :
-            f === :log             ? :(Base.LogFun()) :
-            f === :&               ? :(Base.AndFun()) :
-            f === :|               ? :(Base.OrFun()) :
-            f === :+               ? :(Base.AddFun()) :
-            f === :*               ? :(Base.MulFun()) :
-            f === :scalarmax       ? :(Base.MaxFun()) :
-            f === :scalarmin       ? :(Base.MinFun()) :
-            f === :centralizedabs2fun ? :(Base.CentralizedAbs2Fun) :
-            f
-        if VERSION >= v"0.4.0-dev+4902"
-            f = f === :<           ? :(Base.LessFun()) :
-                f === :>           ? :(Base.MoreFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-dev+4902"
-            f = f === :conj        ? :(Base.ConjFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-dev+6254"
-            f = f === :-           ? :(Base.SubFun()) :
-                f === :^           ? :(Base.PowFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-dev+6256"
-            f = f === :/           ? :(Base.RDivFun()) :
-                f === :\           ? :(Base.LDivFun()) :
-                f === :div         ? :(Base.IDivFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-dev+6353"
-            f = f === :$           ? :(Base.XorFun()) :
-                f === :.+          ? :(Base.DotAddFun()) :
-                f === :.-          ? :(Base.DotSubFun()) :
-                f === :.*          ? :(Base.DotMulFun()) :
-                f === :mod         ? :(Base.ModFun()) :
-                f === :rem         ? :(Base.RemFun()) :
-                # DotRemFun is defined, but ::call(::DotRemFun, ...) is not until later
-                #f === :.%          ? :(Base.DotRemFun()) :
-                f === :.<<         ? :(Base.DotLSFun()) :
-                f === :.>>         ? :(Base.DotRSFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-dev+6359"
-            f = f === :./          ? :(Base.DotRDivFun()) :
-                f
-        end
-        if VERSION >= v"0.4.0-rc1+59"
-            f = f === :max         ? :(Base.ElementwiseMaxFun()) :
-                f === :min         ? :(Base.ElementwiseMinFun()) :
-                f
-        end
-        if VERSION >= v"0.5.0-dev+741"
-            f = f === :complex     ? :(Base.SparseArrays.ComplexFun()) :
-                f === :dot         ? :(Base.SparseArrays.DotFun()) :
-                f
-        end
-        if VERSION >= v"0.5.0-dev+1472"
-            f = f === Symbol(".÷") ? :(Base.DotIDivFun()) :
-                f === :.%          ? :(Base.DotRemFun()) :
-                f
-        end
-        f
-    end
+    f === :scalarmax       ? :(Base.scalarmax) :
+    f === :scalarmin       ? :(Base.scalarmin) :
+    f === :centralizedabs2fun ? :(primarytype(typeof(Base.centralizedabs2fun(0)))) :
+    f
 end
 
 if !isdefined(Base, :Threads)
@@ -852,124 +367,7 @@ else
     import Base.AsyncCondition
 end
 
-# 0.5.0-dev+2301, JuliaLang/julia#14766
-if !isdefined(Base, :unsafe_write)
-    const unsafe_write = write
-    export unsafe_write
-end
-
-# JuliaLang/julia#16219
-if !isdefined(Base, @compat Symbol("@static"))
-     macro static(ex)
-        if isa(ex, Expr)
-            if ex.head === :if
-                cond = eval(current_module(), ex.args[1])
-                if cond
-                    return esc(ex.args[2])
-                elseif length(ex.args) == 3
-                    return esc(ex.args[3])
-                else
-                    return nothing
-                end
-            end
-        end
-        throw(ArgumentError("invalid @static macro"))
-    end
-    export @static
-end
-
-# JuliaLang/julia#14082
-if VERSION < v"0.5.0-dev+4295"
-    function repeat(A::AbstractArray;
-                    inner=ntuple(x->1, ndims(A)),
-                    outer=ntuple(x->1, ndims(A)))
-        ndims_in = ndims(A)
-        length_inner = length(inner)
-        length_outer = length(outer)
-
-        length_inner >= ndims_in || throw(ArgumentError("number of inner repetitions ($(length(inner))) cannot be less than number of dimensions of input ($(ndims(A)))"))
-        length_outer >= ndims_in || throw(ArgumentError("number of outer repetitions ($(length(outer))) cannot be less than number of dimensions of input ($(ndims(A)))"))
-
-        ndims_out = max(ndims_in, length_inner, length_outer)
-
-        inner = vcat(collect(inner), ones(Int,ndims_out-length_inner))
-        outer = vcat(collect(outer), ones(Int,ndims_out-length_outer))
-
-        size_in = size(A)
-        size_out = ntuple(i->inner[i]*size(A,i)*outer[i],ndims_out)::Dims
-        inner_size_out = ntuple(i->inner[i]*size(A,i),ndims_out)::Dims
-
-        indices_in = Array(Int, ndims_in)
-        indices_out = Array(Int, ndims_out)
-
-        length_out = prod(size_out)
-        R = similar(A, size_out)
-
-        for index_out in 1:length_out
-            indices_out = ind2sub(size_out, index_out)
-            for t in 1:ndims_in
-                # "Project" outer repetitions into inner repetitions
-                indices_in[t] = mod1(indices_out[t], inner_size_out[t])
-                # Find inner repetitions using flooring division
-                indices_in[t] = Base.fld1(indices_in[t], inner[t])
-            end
-            index_in = sub2ind(size_in, indices_in...)
-            R[index_out] = A[index_in]
-        end
-
-        return R
-    end
-else
-    const repeat = Base.repeat
-end
-
-if VERSION < v"0.5.0-dev+4267"
-    if OS_NAME == :Windows
-        const KERNEL = :NT
-    else
-        const KERNEL = OS_NAME
-    end
-
-    @eval is_apple()   = $(KERNEL == :Darwin)
-    @eval is_linux()   = $(KERNEL == :Linux)
-    @eval is_bsd()     = $(KERNEL in (:FreeBSD, :OpenBSD, :NetBSD, :Darwin, :Apple))
-    @eval is_unix()    = $(is_linux() || is_bsd())
-    @eval is_windows() = $(KERNEL == :NT)
-    export is_apple, is_linux, is_bsd, is_unix, is_windows
-else
-    const KERNEL = Sys.KERNEL
-end
-
 import Base: srand, rand, rand!
-
-if isdefined(Core, :String) && isdefined(Core, :AbstractString)
-    # Not exported in order to not break code on 0.5
-    const UTF8String = Core.String
-    const ASCIIString = Core.String
-else
-    const String = Base.ByteString
-    if VERSION >= v"0.4.0-dev+5243"
-        @compat (::Type{Base.ByteString})(io::Base.AbstractIOBuffer) = bytestring(io)
-    elseif VERSION >= v"0.4.0-dev+1246"
-        @compat (::Type{Base.ByteString})(io::IOBuffer) = bytestring(io)
-    end
-    if VERSION >= v"0.4.0-dev+1246"
-        @compat (::Type{Base.ByteString})(s::Cstring) = bytestring(s)
-        @compat (::Type{Base.ByteString})(v::Vector{UInt8}) = bytestring(v)
-        @compat (::Type{Base.ByteString})(p::Union{Ptr{Int8},Ptr{UInt8}}) = bytestring(p)
-        @compat (::Type{Base.ByteString})(p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) = bytestring(p, len)
-        @compat (::Type{Base.ByteString})(s::AbstractString) = bytestring(s)
-    end
-end
-
-if VERSION < v"0.5.0-dev+2285"
-    fieldoffset(T, i) = @compat UInt(fieldoffsets(T)[i])
-    export fieldoffset
-end
-
-if !isdefined(Base, :view)
-    const view = slice
-end
 
 if !isdefined(Base, :pointer_to_string)
 
@@ -982,18 +380,6 @@ if !isdefined(Base, :pointer_to_string)
     pointer_to_string(p::Ptr{UInt8}, own::Bool=false) =
         pointer_to_string(p, ccall(:strlen, Csize_t, (Cstring,), p), own)
 
-end
-
-if VERSION < v"0.5.0-dev+4612"
-    export unsafe_string, unsafe_wrap
-    unsafe_wrap(::Type{Compat.String}, p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), own::Bool=false) = pointer_to_string(convert(Ptr{UInt8}, p), own)
-    unsafe_wrap(::Type{Compat.String}, p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), len, own::Bool=false) = pointer_to_string(convert(Ptr{UInt8}, p), len, own)
-    unsafe_wrap(::Type{Array}, p::Ptr, dims, own::Bool=false) = pointer_to_array(p, dims, own)
-    unsafe_string(p::@compat(Union{Ptr{Int8},Ptr{UInt8}})) = bytestring(p)
-    unsafe_string(p::@compat(Union{Ptr{Int8},Ptr{UInt8}}), len) = bytestring(p, len)
-    if Cstring != Ptr{UInt8}
-        unsafe_string(p::Cstring) = unsafe_string(Ptr{UInt8}(p))
-    end
 end
 
 if !isdefined(Base, :allunique)
@@ -1023,32 +409,6 @@ else
     import Base.promote_eltype_op
 end
 
-if VERSION < v"0.5.0-dev+4351"
-    Base.join(io::IO, items) =
-        print_joined(io, items)
-    Base.join(io::IO, items, delim) =
-        print_joined(io, items, delim)
-    Base.join(io::IO, items, delim, last) =
-        print_joined(io, items, delim, last)
-    Base.unescape_string(io, s::AbstractString) =
-        print_unescaped(io, s)
-    Base.escape_string(io, str::AbstractString, esc::AbstractString) =
-        print_escaped(io, str, esc)
-end
-
-if VERSION < v"0.5.0-dev+4340"
-    Base.show(io::IO, mime, x) = writemime(io, mime, x)
-end
-
-if VERSION >= v"0.5.0-dev+4338"
-    import Base.LinAlg.BLAS.@blasfunc
-elseif VERSION >= v"0.5.0-dev+1871"
-    import Base.@blasfunc
-else
-    macro blasfunc(x)
-        Expr(:quote, Base.blasfunc(x))
-    end
-end
 
 import Base: redirect_stdin, redirect_stdout, redirect_stderr
 if VERSION < v"0.6.0-dev.374"
@@ -1107,18 +467,8 @@ macro dep_vectorize_2arg(S, f)
     end
 end
 
-if VERSION < v"0.5.0-dev+4677"
-    using Base.LinAlg: HermOrSym
-    Base.chol(A::HermOrSym) = Base.LinAlg.chol!(A.uplo == 'U' ? copy(A.data) : A.data')
-    Base.cholfact(A::HermOrSym) = cholfact(A.data, Symbol(A.uplo))
-    Base.cholfact!(A::HermOrSym) = cholfact!(A.data, Symbol(A.uplo))
-
-    Base.cholfact(A::HermOrSym, T::Type) = cholfact(A.data, Symbol(A.uplo), T)
-    Base.cholfact!(A::HermOrSym, T::Type) = cholfact!(A.data, Symbol(A.uplo), T)
-end
-
 # broadcast over same length tuples, from julia#16986
-if v"0.5.0-dev+4002" ≤ VERSION < v"0.6.0-dev.693"
+if VERSION < v"0.6.0-dev.693"
     Base.Broadcast.broadcast{N}(f, t::NTuple{N}, ts::Vararg{NTuple{N}}) = map(f, t, ts...)
 end
 
@@ -1172,32 +522,6 @@ if VERSION < v"0.6.0-dev.1256"
     Base.take!(io::Base.AbstractIOBuffer) = takebuf_array(io)
 end
 
-# julia #17323
-if VERSION < v"0.5.0-dev+5380"
-    export transcode
-    transcode{T<:Compat.String}(::Type{T}, src::Union{Compat.String,Vector{UInt8}}) = utf8(src)
-    transcode{T<:Compat.String}(::Type{T}, src::Vector{UInt16}) = utf8(utf16(src))
-    transcode{T<:Compat.String}(::Type{T}, src::Vector{UInt32}) = utf8(utf32(src))
-    transcode(::Type{UInt8}, src::Vector{UInt8}) = src
-    transcode(::Type{UInt8}, src) = transcode(Compat.String, src).data
-    function transcode(::Type{UInt16}, src::Union{Compat.String,Vector{UInt8}})
-        d = utf16(utf8(src)).data
-        return resize!(d, length(d)-1) # strip off trailing NUL codeunit
-    end
-    function transcode(::Type{UInt32}, src::Union{Compat.String,Vector{UInt8}})
-        d = utf32(utf8(src)).data
-        return resize!(d, length(d)-1) # strip off trailing NUL codeunit
-    end
-    transcode(::Type{UInt16}, src::Vector{UInt16}) = src
-    transcode(::Type{UInt32}, src::Vector{UInt32}) = src
-    if Cwchar_t == Int32
-        transcode(::Type{Cwchar_t}, src::Vector{Cwchar_t}) = src
-        transcode(::Type{Cwchar_t}, src) = reinterpret(Cwchar_t, transcode(UInt32, src))
-        transcode(::Type{UInt8}, src::Vector{Cwchar_t}) = transcode(UInt8, reinterpret(UInt32, src))
-        transcode(T, src::Vector{Cwchar_t}) = transcode(T, reinterpret(UInt32, src))
-    end
-end
-
 # julia #17155 function composition and negation
 if VERSION < v"0.6.0-dev.1883"
     export ∘
@@ -1205,20 +529,8 @@ if VERSION < v"0.6.0-dev.1883"
     @compat Base.:!(f::Function) = (x...)->!f(x...)
 end
 
-if VERSION < v"0.5.0-dev+1450"
-    Base.Diagonal(v::AbstractVector) = Diagonal(collect(v))
-end
-if VERSION < v"0.5.0-dev+3669"
-    using Base: promote_op
-    import Base: *
-    eval(Expr(:typealias, :(SubMatrix{T}), :(SubArray{T,2})))
-    (*)(A::SubMatrix, D::Diagonal) =
-        scale!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A, D.diag)
-    (*)(D::Diagonal, A::SubMatrix) =
-        scale!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), D.diag, A)
-end
 
-if VERSION >= v"0.5.0-dev+5509" && VERSION < v"0.6.0-dev.1632"
+if VERSION < v"0.6.0-dev.1632"
     # To work around unsupported syntax on Julia 0.4
     include_string("export .&, .|")
     include_string(".&(xs...) = broadcast(&, xs...)")
@@ -1232,13 +544,6 @@ if VERSION < v"0.6.0-dev.2093" # Compat.isapprox to allow for NaNs
     end
 else
     import Base.isapprox
-end
-
-# julia #13998 single-argument min and max
-if VERSION < v"0.5.0-dev+1279"
-    Base.min(x::Real) = x
-    Base.max(x::Real) = x
-    Base.minmax(x::Real) = (x, x)
 end
 
 module TypeUtils
@@ -1271,152 +576,6 @@ if VERSION < v"0.6.0-dev.1024"
         using Base: countfrom, cycle, drop, enumerate, repeated, rest, take,
                     zip
         using Compat
-
-        # julia #14805
-        if VERSION < v"0.5.0-dev+3256"
-            include_string("""
-            immutable Flatten{I}
-                it::I
-            end
-            """)
-
-            flatten(itr) = Flatten(itr)
-
-            eltype{I}(::Type{Flatten{I}}) = eltype(eltype(I))
-
-            function start(f::Flatten)
-                local inner, s2
-                s = start(f.it)
-                d = done(f.it, s)
-                # this is a simple way to make this function type stable
-                d && throw(ArgumentError("argument to Flatten must contain at least one iterator"))
-                while !d
-                    inner, s = next(f.it, s)
-                    s2 = start(inner)
-                    !done(inner, s2) && break
-                    d = done(f.it, s)
-                end
-                return s, inner, s2
-            end
-
-            @inline function next(f::Flatten, state)
-                s, inner, s2 = state
-                val, s2 = next(inner, s2)
-                while done(inner, s2) && !done(f.it, s)
-                    inner, s = next(f.it, s)
-                    s2 = start(inner)
-                end
-                return val, (s, inner, s2)
-            end
-
-            @inline function done(f::Flatten, state)
-                s, inner, s2 = state
-                return done(f.it, s) && done(inner, s2)
-            end
-        else
-            using Base: flatten
-        end
-
-        # julia #14596
-        if VERSION < v"0.5.0-dev+2305"
-            # Product -- cartesian product of iterators
-            @compat abstract type AbstractProdIterator end
-
-            include_string("""
-            immutable Prod2{I1, I2} <: AbstractProdIterator
-                a::I1
-                b::I2
-            end
-            """)
-
-            product(a) = Zip1(a)
-            product(a, b) = Prod2(a, b)
-            eltype{I1,I2}(::Type{Prod2{I1,I2}}) = Tuple{eltype(I1), eltype(I2)}
-            length(p::AbstractProdIterator) = length(p.a)*length(p.b)
-
-            function start(p::AbstractProdIterator)
-                s1, s2 = start(p.a), start(p.b)
-                s1, s2, Nullable{eltype(p.b)}(), (done(p.a,s1) || done(p.b,s2))
-            end
-
-            @inline function prod_next(p, st)
-                s1, s2 = st[1], st[2]
-                v1, s1 = next(p.a, s1)
-
-                nv2 = st[3]
-                if isnull(nv2)
-                    v2, s2 = next(p.b, s2)
-                else
-                    v2 = nv2.value
-                end
-
-                if done(p.a, s1)
-                    return (v1,v2), (start(p.a), s2, oftype(nv2,nothing), done(p.b,s2))
-                end
-                return (v1,v2), (s1, s2, Nullable(v2), false)
-            end
-
-            @inline next(p::Prod2, st) = prod_next(p, st)
-            @inline done(p::AbstractProdIterator, st) = st[4]
-
-            include_string("""
-            immutable Prod{I1, I2<:AbstractProdIterator} <: AbstractProdIterator
-                a::I1
-                b::I2
-            end
-            """)
-
-            product(a, b, c...) = Prod(a, product(b, c...))
-            eltype{I1,I2}(::Type{Prod{I1,I2}}) = tuple_type_cons(eltype(I1), eltype(I2))
-
-            @inline function next{I1,I2}(p::Prod{I1,I2}, st)
-                x = prod_next(p, st)
-                ((x[1][1],x[1][2]...), x[2])
-            end
-        else
-            using Base: product
-        end
-
-        # julia #15409
-        if VERSION < v"0.5.0-dev+3510"
-            partition{T}(c::T, n::Int) = PartitionIterator{T}(c, n)
-
-            include_string("""
-            type PartitionIterator{T}
-                c::T
-                n::Int
-            end
-            """)
-
-            eltype{T}(::Type{PartitionIterator{T}}) = Vector{eltype(T)}
-
-            function length(itr::PartitionIterator)
-                l = length(itr.c)
-                return div(l, itr.n) + ((mod(l, itr.n) > 0) ? 1 : 0)
-            end
-
-            start(itr::PartitionIterator) = start(itr.c)
-
-            done(itr::PartitionIterator, state) = done(itr.c, state)
-
-            function next{T<:Vector}(itr::PartitionIterator{T}, state)
-                l = state
-                r = min(state + itr.n-1, length(itr.c))
-                return sub(itr.c, l:r), r + 1
-            end
-
-            function next(itr::PartitionIterator, state)
-                v = Vector{eltype(itr.c)}(itr.n)
-                i = 0
-                while !done(itr.c, state) && i < itr.n
-                    i += 1
-                    v[i], state = next(itr.c, state)
-                end
-                return resize!(v, i), state
-            end
-        else
-            using Base: partition
-        end
     end
 else
     using Base: Iterators
@@ -1500,20 +659,6 @@ if isdefined(Base, :invokelatest)
     import Base.invokelatest
 else
     invokelatest(f, args...) = eval(current_module(), Expr(:call, f, map(QuoteNode, args)...))
-end
-
-# https://github.com/JuliaLang/julia/pull/21257
-if v"0.5.0-rc1+46" <= VERSION < v"0.6.0-pre.beta.28"
-    collect(A) = collect_indices(indices(A), A)
-    collect_indices(::Tuple{}, A) = copy!(Array{eltype(A)}(), A)
-    collect_indices(indsA::Tuple{Vararg{Base.OneTo}}, A) =
-        copy!(Array{eltype(A)}(map(length, indsA)), A)
-    function collect_indices(indsA, A)
-        B = Array{eltype(A)}(map(length, indsA))
-        copy!(B, CartesianRange(indices(B)), A, CartesianRange(indsA))
-    end
-else
-    const collect = Base.collect
 end
 
 # https://github.com/JuliaLang/julia/pull/21378

--- a/src/to-be-deprecated.jl
+++ b/src/to-be-deprecated.jl
@@ -2,17 +2,15 @@
 # See also ngenerate.jl.
 
 macro Dict(pairs...)
-    esc(Expr(:block, # :(Base.depwarn("@Dict is deprecated, use Dict instead", Symbol("@Dict"))),
+    esc(Expr(:block, :(Base.depwarn("@Dict is deprecated, use Dict instead", Symbol("@Dict"))),
                        Expr(:call, :Dict, pairs...)))
 end
 macro AnyDict(pairs...)
-    esc(Expr(:block, # :(Base.depwarn("@AnyDict is deprecated, use Dict{Any,Any} instead",
-                     #               Symbol("@AnyDict"))),
+    esc(Expr(:block, :(Base.depwarn("@AnyDict is deprecated, use Dict{Any,Any} instead",
+                                    Symbol("@AnyDict"))),
              Expr(:call, :(Base.AnyDict), pairs...)))
 end
 
-if VERSION >= v"0.4.0-dev+3184"
-    include("ngenerate.jl")
-    using .CompatCartesian
-    export @ngenerate, @nsplat
-end
+include("ngenerate.jl")
+using .CompatCartesian
+export @ngenerate, @nsplat


### PR DESCRIPTION
Initial work at dropping 0.4, but I'm guessing there is other 0.4 specific code that wasn't in a version check (e.g., `!isdefined(...)`). I'm guessing we also need to properly deprecate any Compat calls being removed to point to the appropriate Base method?