### PR TITLE
Add atsign-compat support for `CartesianRange`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.collect(A)` returns an `Array`, no matter what indices the array `A` has. [#21257]
 
+* `@compat foo(::CartesianRange{N})` to replace the former
+  `foo(::CartesianRange{CartesianIndex{N}})` ([#20974]). Note that
+  `CartesianRange` now has two type parameters, so using them as
+  fields in other `struct`s requires manual intervention.
+
 ## Module Aliases
 
 * In 0.6, some 0.5 iterator functions have been moved to the `Base.Iterators`
@@ -280,6 +285,7 @@ includes this fix. Find the minimum version from there.
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
 [#20418]: https://github.com/JuliaLang/julia/issues/20418
 [#20500]: https://github.com/JuliaLang/julia/issues/20500
+[#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21257]: https://github.com/JuliaLang/julia/issues/21257
 [#21346]: https://github.com/JuliaLang/julia/issues/21346
 [#22064]: https://github.com/JuliaLang/julia/issues/22064

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -178,6 +178,14 @@ function _compat(ex::Expr)
             end
         end
     end
+    if VERSION < v"0.7.0-DEV.880"
+        if ex.head == :curly && ex.args[1] == :CartesianRange && length(ex.args) >= 2
+            a = ex.args[2]
+            if a != :CartesianIndex && !(isa(a, Expr) && a.head == :curly && a.args[1] == :CartesianIndex)
+                return Expr(:curly, :CartesianRange, Expr(:curly, :CartesianIndex, ex.args[2]))
+            end
+        end
+    end
     return Expr(ex.head, map(_compat, ex.args)...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1868,6 +1868,20 @@ let
     @test_throws MethodError Dates.Month(1) < Dates.Day(1)
 end
 
+let
+    @compat cr(::CartesianRange{2}) = 2
+    @test cr(CartesianRange((5, 3))) == 2
+    @test_throws MethodError cr(CartesianRange((5, 3, 2)))
+end
+if VERSION < v"0.7.0-DEV.880"
+    # ensure we don't bork any non-updated expressions
+    let
+        @compat cr(::CartesianRange{CartesianIndex{2}}) = 2
+        @test cr(CartesianRange((5, 3))) == 2
+        @test_throws MethodError cr(CartesianRange((5, 3, 2)))
+    end
+end
+
 include("deprecated.jl")
 
 nothing


### PR DESCRIPTION
This won't pass on nightly because there's some issue regarding `qr` (CC @andreasnoack) that I don't have time to debug. I have verified that if you comment those tests out, this passes on (my) current master.
