### PR TITLE
Compat for chol(::UniformScaling) and fallback for logdet()

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Val(x)` constructs `Val{x}()`. ([#22475])
 
+* `chol` and `chol!` for `UniformScalings` ([#22633]).
+
+* `logdet` for `Number`s ([#22629]).
+
 ## Renamed functions
 
 
@@ -286,3 +290,5 @@ includes this fix. Find the minimum version from there.
 [#21346]: https://github.com/JuliaLang/julia/issues/21346
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
 [#22475]: https://github.com/JuliaLang/julia/issues/22475
+[#22633]: https://github.com/JuliaLang/julia/issues/22633
+[#22629]: https://github.com/JuliaLang/julia/issues/22629

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -613,6 +613,19 @@ if VERSION < v"0.7.0-DEV.843"
     (::Type{Val})(x) = (Base.@_pure_meta; Val{x}())
 end
 
+# https://github.com/JuliaLang/julia/pull/22629
+if VERSION < v"0.7.0-DEV.848"
+    import Base: logdet
+    logdet(A) = log(det(A))
+end
+
+# https://github.com/JuliaLang/julia/pull/22633
+if VERSION < v"0.7.0-DEV.1041"
+    import Base.LinAlg: chol, chol!
+    chol!(J::UniformScaling, uplo) = UniformScaling(chol!(J.λ, uplo))
+    chol(J::UniformScaling, args...) = UniformScaling(chol(J.λ, args...))
+end
+
 include("deprecated.jl")
 
 # https://github.com/JuliaLang/julia/pull/21746

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1879,7 +1879,7 @@ end
 # PR 22633
 for T in (Float64, Complex64, BigFloat, Int)
     λ = T(4)
-    @test chol(λ*I) ≈ √λ*I
+    @test chol(λ*I).λ ≈ √λ
     @test_throws Union{ArgumentError,LinAlg.PosDefException} chol(-λ*I)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1873,6 +1873,17 @@ let
     @test_throws MethodError Dates.Month(1) < Dates.Day(1)
 end
 
+# PR 22629
+@test logdet(0.5) == log(det(0.5))
+
+# PR 22633
+for T in (Float64, Complex64, BigFloat, Int)
+    λ = T(4)
+    @test chol(λ*I) ≈ √λ*I
+    @test_throws Union{ArgumentError,LinAlg.PosDefException} chol(-λ*I)
+end
+
+
 include("deprecated.jl")
 
 nothing


### PR DESCRIPTION
As suggested in https://github.com/JuliaLang/METADATA.jl/pull/10316. I did not hook into ``_chol!`` because that interface is private and volatile. 