### PR TITLE
only expand if statements that declare new globals if they will be executed

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -411,14 +411,14 @@ if VERSION < v"0.6.0-dev.848"
 end
 
 # julia#18977
-if !isdefined(Base, :xor)
+@static if !isdefined(Base, :xor)
     const xor = $
     const ⊻ = xor
     export xor, ⊻
 end
 
 # julia#19246
-if !isdefined(Base, :numerator)
+@static if !isdefined(Base, :numerator)
     const numerator = num
     const denominator = den
     export numerator, denominator
@@ -433,7 +433,7 @@ if !isdefined(Base, :iszero)
 end
 
 # julia　#20407
-if !isdefined(Base, :(>:))
+@static if !isdefined(Base, :(>:))
     const >: = let
         _issupertype(a::ANY, b::ANY) = issubtype(b, a)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -383,6 +383,7 @@ end
 @test fma(3,4,5) == 3*4+5 == muladd(3,4,5)
 
 if VERSION < v"0.5.0-dev+5271"
+    local s
     # is_valid_utf32
     s = utf32("abc")
     @test isvalid(s)


### PR DESCRIPTION
this ensures that we only introduce bindings for values that we define here

A couple more that I missed in #388, needed for the tests to continue passing