### PR TITLE
Remove compat 0.7 pkg eval logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Compat](http://pkg.julialang.org/badges/Compat_0.4.svg)](http://pkg.julialang.org/?pkg=Compat&ver=0.4)
 [![Compat](http://pkg.julialang.org/badges/Compat_0.5.svg)](http://pkg.julialang.org/?pkg=Compat&ver=0.5)
 [![Compat](http://pkg.julialang.org/badges/Compat_0.6.svg)](http://pkg.julialang.org/?pkg=Compat&ver=0.6)
-[![Compat](http://pkg.julialang.org/badges/Compat_0.7.svg)](http://pkg.julialang.org/?pkg=Compat&ver=0.7)
 
 The **Compat** package is designed to ease interoperability between
 older and newer versions of the [Julia


### PR DESCRIPTION
Currently it doesn't exist so it does not render at all when viewing the readme. This removes the logo.