### PR TITLE
Backport reshape and ntuple Val() APIs to 0.5 and 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Cmd` elements can be accessed as if the `Cmd` were an array of strings for 0.6 and below ([#21197]).
 
-* `Val(x)` constructs `Val{x}()`. The `reshape` and `ntuple` APIs are extended to support `Val{x}()` arguments on 0.6 and below. ([#22475])
+* `Val(x)` constructs `Val{x}()`. ([#22475])
+
+* The `reshape` and `ntuple` APIs are extended to support `Val{x}()` arguments on 0.6 and below.
 
 * `chol` and `chol!` for `UniformScalings` ([#22633]).
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Cmd` elements can be accessed as if the `Cmd` were an array of strings for 0.6 and below ([#21197]).
 
-* `Val(x)` constructs `Val{x}()`. ([#22475])
+* `Val(x)` constructs `Val{x}()`. The `reshape` and `ntuple` APIs are extended to support `Val{x}()` arguments on 0.6 and below. ([#22475])
 
 * `chol` and `chol!` for `UniformScalings` ([#22633]).
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -463,6 +463,13 @@ if VERSION < v"0.7.0-DEV.843"
     (::Type{Val})(x) = (Base.@_pure_meta; Val{x}())
 end
 
+# Backport reshape API changes for reshaping to a given number of dimensions
+if VERSION < v"0.7.0-DEV.843" # https://github.com/JuliaLang/julia/pull/22475
+    # The machinery exists, but it's in terms of Type{Val{N}} instead of Val{N}
+    import Base: reshape
+    Base.reshape{N}(parent::AbstractArray, ndims::Val{N}) = reshape(parent, Val{N})
+end
+
 # https://github.com/JuliaLang/julia/pull/22629
 if VERSION < v"0.7.0-DEV.848"
     import Base: logdet

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -461,13 +461,11 @@ end
 if VERSION < v"0.7.0-DEV.843"
     import Base: Val
     (::Type{Val})(x) = (Base.@_pure_meta; Val{x}())
-end
-
-# Backport reshape API changes for reshaping to a given number of dimensions
-if VERSION < v"0.7.0-DEV.843" # https://github.com/JuliaLang/julia/pull/22475
-    # The machinery exists, but it's in terms of Type{Val{N}} instead of Val{N}
+    # Also add methods for Val(x) that were previously Val{x}
     import Base: reshape
-    Base.reshape{N}(parent::AbstractArray, ndims::Val{N}) = reshape(parent, Val{N})
+    reshape{N}(parent::AbstractArray, ndims::Val{N}) = reshape(parent, Val{N})
+    import Base: ntuple
+    ntuple{F,N}(f::F, ::Val{N}) = ntuple(f, Val{N})
 end
 
 # https://github.com/JuliaLang/julia/pull/22629

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -702,6 +702,12 @@ let
     end
 end
 
+# ntuple with Val(N)
+# 0.7
+@test @inferred(ntuple(x->1, Val(3))) == (1,1,1)
+@test @inferred(ntuple(x->x, Val(0))) == ()
+@test @inferred(ntuple(x->x, Val(5))) == (1,2,3,4,5)
+
 # @nospecialize
 # 0.7
 no_specialize(@nospecialize(x)) = sin(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -684,6 +684,24 @@ begin
     @test firstlast(Val(false)) == "Last"
 end
 
+# Reshape to a given number of dimensions using Val(N)
+# 0.7
+let
+    for A in (rand(()), rand(2), rand(2,3), rand(2,3,5), rand(2,3,5,7)), N in (1,2,3,4,5,6)
+        B = @inferred reshape(A, Val(N))
+        @test ndims(B) == N
+        if N < ndims(A)
+            new_sz = (size(A)[1:N-1]..., prod(size(A)[N:end]))
+        elseif N == ndims(A)
+            new_sz = size(A)
+        else
+            new_sz = (size(A)..., ntuple(x->1, N-ndims(A))...)
+        end
+        @test size(B) == new_sz
+        @test B == reshape(A, new_sz)
+    end
+end
+
 # @nospecialize
 # 0.7
 no_specialize(@nospecialize(x)) = sin(1)


### PR DESCRIPTION
The functionality is there on both 0.5 and 0.6; we just need to convert Val(N) to Val{N}.