### PR TITLE
Add at-isdefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `@nospecialize` has been added ([#22666]).
 
+* Julia 0.7 introduced `@isdefined` to replace `isdefined`, which only works for globals
+  ([#22281]). It isn't possible to achieve the 0.7 behavior in earlier versions of Julia,
+  but an `@isdefined` macro is defined here to avoid deprecation warnings when supporting
+  both 0.7 and earlier versions.
+
 ## Other changes
 
 * On versions of Julia that do not contain a Base.Threads module, Compat defines a Threads module containing a no-op `@threads` macro.
@@ -318,6 +323,7 @@ includes this fix. Find the minimum version from there.
 [#21709]: https://github.com/JuliaLang/julia/issues/21709
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
 [#22182]: https://github.com/JuliaLang/julia/issues/22182
+[#22281]: https://github.com/JuliaLang/julia/issues/22281
 [#22350]: https://github.com/JuliaLang/julia/issues/22350
 [#22475]: https://github.com/JuliaLang/julia/issues/22475
 [#22629]: https://github.com/JuliaLang/julia/issues/22629

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -663,6 +663,14 @@ end
     export isconcrete
 end
 
+# 0.7.0-DEV.518
+@static if !isdefined(Base, Symbol("@isdefined"))
+    macro isdefined(x)
+        :(isdefined($(QuoteNode(x))))
+    end
+    export @isdefined
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -823,6 +823,11 @@ end
 # 0.7
 @test isconcrete(Int)
 
+# 0.7
+@test !@isdefined(somevar)
+somevar = 1
+@test @isdefined(somevar)
+
 if VERSION < v"0.6.0"
     include("deprecated.jl")
 end


### PR DESCRIPTION
Note that this is **NOT** functionally equivalent to `@isdefined` on 0.7; that isn't possible on earlier versions. Instead this defines `@isdefined` to wrap `isdefined`, which can only check for global variables.