### PR TITLE
Add @compat for standard library imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Currently, the `@compat` macro supports the following syntaxes:
   `CartesianRange` now has two type parameters, so using them as
   fields in other `struct`s requires manual intervention.
 
+* `@compat using Test`, `@compat using SharedArrays`, `@compat using Mmap`, and `@compat
+  using DelimitedFiles` are provided on versions older than 0.7, where these are not yet
+  part of the standard library. ([#23931])
+
 ## Module Aliases
 
 * In 0.6, some 0.5 iterator functions have been moved to the `Base.Iterators`
@@ -296,6 +300,7 @@ includes this fix. Find the minimum version from there.
 [#18977]: https://github.com/JuliaLang/julia/issues/18977
 [#19088]: https://github.com/JuliaLang/julia/issues/19088
 [#19246]: https://github.com/JuliaLang/julia/issues/19246
+[#19331]: https://github.com/JuliaLang/julia/issues/19331
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19635]: https://github.com/JuliaLang/julia/issues/19635
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
@@ -315,6 +320,7 @@ includes this fix. Find the minimum version from there.
 [#21257]: https://github.com/JuliaLang/julia/issues/21257
 [#21346]: https://github.com/JuliaLang/julia/issues/21346
 [#21378]: https://github.com/JuliaLang/julia/issues/21378
+[#21419]: https://github.com/JuliaLang/julia/issues/21419
 [#21709]: https://github.com/JuliaLang/julia/issues/21709
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
 [#22182]: https://github.com/JuliaLang/julia/issues/22182
@@ -331,3 +337,4 @@ includes this fix. Find the minimum version from there.
 [#23427]: https://github.com/JuliaLang/julia/issues/23427
 [#23570]: https://github.com/JuliaLang/julia/issues/23570
 [#23666]: https://github.com/JuliaLang/julia/issues/23666
+[#23931]: https://github.com/JuliaLang/julia/issues/23931

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Compat
-using Base.Test
+@compat using Test
 
 # Issue #291
 # 0.6
@@ -513,7 +513,7 @@ module Test18839
 
 using Compat
 using Compat.Iterators
-using Base.Test
+@compat using Test
 
 @test collect(take(countfrom(2), 3)) == [2, 3, 4]
 @test collect(take(cycle(5:8), 9)) == [5:8; 5:8; 5]
@@ -627,7 +627,8 @@ b = Compat.collect(a)
 
 # PR 22064
 module Test22064
-using Base.Test, Compat
+using Compat
+@compat using Test
 @test (@__MODULE__) === Test22064
 end
 
@@ -822,6 +823,19 @@ end
 
 # 0.7
 @test isconcrete(Int)
+
+# 0.7
+module Test23876
+    using Compat
+    @compat using Test
+    @compat import DelimitedFiles
+    @compat using Mmap, SharedArrays
+    @test isdefined(@__MODULE__, :DelimitedFiles)
+    @test isdefined(SharedArrays, :SharedArray)
+    @test isdefined(@__MODULE__, :SharedArray)
+    @test isdefined(@__MODULE__, :procs)
+    @test isdefined(Mmap, :mmap)
+end
 
 if VERSION < v"0.6.0"
     include("deprecated.jl")


### PR DESCRIPTION
Alternative to #404.

See https://github.com/JuliaLang/julia/issues/23931.

The `SharedArrays` module is emulated instead of real.