### PR TITLE
Add constructors for `Matrix{T}`, `Array{T}`, and `SparseMatrixCSC{T}` from `UniformScaling`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `diagm` and `spdiagm` accept pairs mapping diagonals to vectors ([#24047], [#23757])
 
+* Constructors for `Matrix{T}` and `SparseMatrixCSC{T}` from `UniformScaling` ([#24372])
+
 ## Renaming
 
 
@@ -354,3 +356,4 @@ includes this fix. Find the minimum version from there.
 [#23931]: https://github.com/JuliaLang/julia/issues/23931
 [#24047]: https://github.com/JuliaLang/julia/issues/24047
 [#24282]: https://github.com/JuliaLang/julia/issues/24282
+[#24372]: https://github.com/JuliaLang/julia/issues/24372

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `diagm` and `spdiagm` accept pairs mapping diagonals to vectors ([#24047], [#23757])
 
-* Constructors for `Matrix{T}` and `SparseMatrixCSC{T}` from `UniformScaling` ([#24372])
+* Constructors for `Matrix{T}`, `Array{T}`, and `SparseMatrixCSC{T}` from `UniformScaling` ([#24372], [#24657])
 
 ## Renaming
 
@@ -357,3 +357,4 @@ includes this fix. Find the minimum version from there.
 [#24047]: https://github.com/JuliaLang/julia/issues/24047
 [#24282]: https://github.com/JuliaLang/julia/issues/24282
 [#24372]: https://github.com/JuliaLang/julia/issues/24372
+[#24657]: https://github.com/JuliaLang/julia/issues/24657

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -782,6 +782,10 @@ if VERSION < v"0.7.0-DEV.2377"
         SparseMatrixCSC{Tv,Ti}(dims..., colptr, rowval, nzval)
     end
 end
+if VERSION < v"0.7.0-DEV.2543"
+    (::Type{Array{T}}){T}(s::UniformScaling, dims::Dims{2}) = Matrix{T}(s, dims)
+    (::Type{Array{T}}){T}(s::UniformScaling, m::Integer, n::Integer) = Matrix{T}(s, m, n)
+end
 
 include("deprecated.jl")
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -763,6 +763,26 @@ end
     end
 end
 
+if VERSION < v"0.7.0-DEV.2377"
+    (::Type{Matrix{T}}){T}(s::UniformScaling, dims::Dims{2}) = setindex!(zeros(T, dims), T(s.λ), diagind(dims...))
+    (::Type{Matrix{T}}){T}(s::UniformScaling, m::Integer, n::Integer) = Matrix{T}(s, Dims((m, n)))
+
+    (::Type{SparseMatrixCSC{Tv,Ti}}){Tv,Ti}(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC{Tv,Ti}(s, Dims((m, n)))
+    (::Type{SparseMatrixCSC{Tv}}){Tv}(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC{Tv}(s, Dims((m, n)))
+    (::Type{SparseMatrixCSC{Tv}}){Tv}(s::UniformScaling, dims::Dims{2}) = SparseMatrixCSC{Tv,Int}(s, dims)
+    function (::Type{SparseMatrixCSC{Tv,Ti}}){Tv,Ti}(s::UniformScaling, dims::Dims{2})
+        @boundscheck first(dims) < 0 && throw(ArgumentError("first dimension invalid ($(first(dims)) < 0)"))
+        @boundscheck last(dims) < 0 && throw(ArgumentError("second dimension invalid ($(last(dims)) < 0)"))
+        iszero(s.λ) && return spzeros(Tv, Ti, dims...)
+        m, n, k = dims..., min(dims...)
+        nzval = fill!(Vector{Tv}(k), Tv(s.λ))
+        rowval = copy!(Vector{Ti}(k), 1:k)
+        colptr = copy!(Vector{Ti}(n + 1), 1:(k + 1))
+        for i in (k + 2):(n + 1) colptr[i] = (k + 1) end
+        SparseMatrixCSC{Tv,Ti}(dims..., colptr, rowval, nzval)
+    end
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -873,6 +873,16 @@ end
 @test spdiagm(0 => ones(2), -1 => ones(2)) == [1.0 0.0 0.0; 1.0 1.0 0.0; 0.0 1.0 0.0]
 @test spdiagm(0 => ones(2), 1 => ones(2)) == [1.0 1.0 0.0; 0.0 1.0 1.0; 0.0 0.0 0.0]
 
+# 0.7
+let a = [1 0 0; 0 1 0; 0 0 1]
+    @test Matrix{Int}(I, 3, 3)::Matrix{Int} == a
+    @test Matrix{Float64}(I, (3, 2))::Matrix{Float64} == a[:,1:2]
+    @test SparseMatrixCSC{Int}(I, 3, 3)::SparseMatrixCSC{Int,Int} == a
+    @test SparseMatrixCSC{Float64}(I, (3, 2))::SparseMatrixCSC{Float64,Int} == a[:,1:2]
+    @test SparseMatrixCSC{Bool,Int16}(I, (3, 3))::SparseMatrixCSC{Bool,Int16} == a
+    @test SparseMatrixCSC{Complex128,Int8}(I, 3, 2)::SparseMatrixCSC{Complex128,Int8} == a[:,1:2]
+end
+
 if VERSION < v"0.6.0"
     include("deprecated.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -877,6 +877,8 @@ end
 let a = [1 0 0; 0 1 0; 0 0 1]
     @test Matrix{Int}(I, 3, 3)::Matrix{Int} == a
     @test Matrix{Float64}(I, (3, 2))::Matrix{Float64} == a[:,1:2]
+    @test Array{Int}(I, (3, 3))::Matrix{Int} == a
+    @test Array{Float64}(I, 3, 2)::Matrix{Float64} == a[:,1:2]
     @test SparseMatrixCSC{Int}(I, 3, 3)::SparseMatrixCSC{Int,Int} == a
     @test SparseMatrixCSC{Float64}(I, (3, 2))::SparseMatrixCSC{Float64,Int} == a[:,1:2]
     @test SparseMatrixCSC{Bool,Int16}(I, (3, 3))::SparseMatrixCSC{Bool,Int16} == a


### PR DESCRIPTION
I have omitted the variants without explicit element type due to the change of the default element type of `I`.