### PR TITLE
Implement `pairs` like PR 22907

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `IOContext` accepting key-value `Pair`s ([#23271]).
 
+* `pairs` for iterating over key-value `Pair`s ([#22907]).
+
 * `get` do-block syntax supported when using `ENV` ([#23412]).
 
 ## Renaming
@@ -365,6 +367,7 @@ includes this fix. Find the minimum version from there.
 [#22751]: https://github.com/JuliaLang/julia/issues/22751
 [#22761]: https://github.com/JuliaLang/julia/issues/22761
 [#22864]: https://github.com/JuliaLang/julia/issues/22864
+[#22907]: https://github.com/JuliaLang/julia/issues/22907
 [#23051]: https://github.com/JuliaLang/julia/issues/23051
 [#23235]: https://github.com/JuliaLang/julia/issues/23235
 [#23271]: https://github.com/JuliaLang/julia/issues/23271

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -741,6 +741,34 @@ let x = fill!(StringVector(5), 0x61)
     @test pointer(x) == pointer(String(x))
 end
 
+# PR 22907
+using Compat: pairs
+
+# keys, values, pairs
+for A in (rand(2), rand(2,3))
+    local A
+    for (i, v) in pairs(A)
+        @test A[i] == v
+    end
+    @test collect(values(A)) == collect(A)
+end
+
+let A = Dict(:foo=>1, :bar=>3)
+    for (k, v) in pairs(A)
+        @test A[k] == v
+    end
+    @test sort!(collect(pairs(A))) == sort!(collect(A))
+end
+
+let
+    A14 = [11 13; 12 14]
+    R = CartesianRange(indices(A14))
+    @test [a for (a,b) in pairs(IndexLinear(),    A14)] == [1,2,3,4]
+    @test [a for (a,b) in pairs(IndexCartesian(), A14)] == vec(collect(R))
+    @test [b for (a,b) in pairs(IndexLinear(),    A14)] == [11,12,13,14]
+    @test [b for (a,b) in pairs(IndexCartesian(), A14)] == [11,12,13,14]
+end
+
 # Val(x)
 # 0.7
 begin


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/22907/

This also adds the `keys` and `values` methods that were added in the same PR.

Closes #426 