### PR TITLE
Add Compat.Unicode for standard library Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Currently, the `@compat` macro supports the following syntaxes:
   `CartesianRange` now has two type parameters, so using them as
   fields in other `struct`s requires manual intervention.
 
+## Module Aliases
+
+* In 0.6, some 0.5 iterator functions have been moved to the `Base.Iterators`
+  module. Code can be written to work on both 0.5 and 0.6 by `import`ing or
+  `using` the `Compat.Iterators` module instead. ([#18839])
+
 * `using Compat.Test`, `using Compat.SharedArrays`, `using Compat.Mmap`, and `using
   Compat.DelimitedFiles` are provided on versions older than 0.7, where these are not yet
   part of the standard library. ([#23931])
@@ -89,11 +95,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `using Compat.Dates` is provided on versions older than 0.7, where this library is not
   yet a part of the standard library. ([#24459])
 
-## Module Aliases
-
-* In 0.6, some 0.5 iterator functions have been moved to the `Base.Iterators`
-  module. Code can be written to work on both 0.5 and 0.6 by `import`ing or
-  `using` the `Compat.Iterators` module instead. ([#18839])
+* `using Compat.Unicode` is provided on versions older than 0.7, where this library is not
+  yet a part of the standard library. ([#25021])
 
 ## New functions, macros, and methods
 
@@ -236,8 +239,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `IntSet` is now `BitSet` ([#24282])
 
-* `strwidth` and `charwidth` are now merged into `textwidth` ([#23667]).
-
 * `Complex32`, `Complex64`, and `Complex128` are now `ComplexF16`, `ComplexF32`, and
   `ComplexF64`, respectively ([#24647]).
 
@@ -375,7 +376,6 @@ includes this fix. Find the minimum version from there.
 [#23427]: https://github.com/JuliaLang/julia/issues/23427
 [#23570]: https://github.com/JuliaLang/julia/issues/23570
 [#23666]: https://github.com/JuliaLang/julia/issues/23666
-[#23667]: https://github.com/JuliaLang/julia/issues/23667
 [#23757]: https://github.com/JuliaLang/julia/issues/23757
 [#23812]: https://github.com/JuliaLang/julia/issues/23812
 [#23931]: https://github.com/JuliaLang/julia/issues/23931
@@ -389,3 +389,4 @@ includes this fix. Find the minimum version from there.
 [#24652]: https://github.com/JuliaLang/julia/issues/24652
 [#24657]: https://github.com/JuliaLang/julia/issues/24657
 [#24785]: https://github.com/JuliaLang/julia/issues/24785
+[#25021]: https://github.com/JuliaLang/julia/issues/25021

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -869,10 +869,10 @@ end
 
 # 0.7.0-DEV.2915
 module Unicode
-    export normalize, graphemes, isassigned, textwidth, isvalid,
-        islower, isupper, isalpha, isdigit, isxdigit, isnumeric, isalnum,
-        iscntrl, ispunct, isspace, isprint, isgraph,
-        lowercase, uppercase, titlecase, lcfirst, ucfirst
+    export graphemes, textwidth, isvalid,
+           islower, isupper, isalpha, isdigit, isxdigit, isnumeric, isalnum,
+           iscntrl, ispunct, isspace, isprint, isgraph,
+           lowercase, uppercase, titlecase, lcfirst, ucfirst
 
     if VERSION < v"0.7.0-DEV.2915"
         # 0.7.0-DEV.1930

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -882,22 +882,26 @@ module Unicode
         end
 
         isnumeric(c::Char) = isnumber(c)
-        titlecase(c::Char) = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
-            Char(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
 
-        function titlecase(s::AbstractString)
-            startword = true
-            b = IOBuffer()
-            for c in s
-                if isspace(c)
-                    print(b, c)
-                    startword = true
-                else
-                    print(b, startword ? titlecase(c) : c)
-                    startword = false
+        # 0.6.0-dev.1404 (https://github.com/JuliaLang/julia/pull/19469)
+        if !isdefined(Base, :titlecase)
+            titlecase(c::Char) = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
+                Char(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
+
+            function titlecase(s::AbstractString)
+                startword = true
+                b = IOBuffer()
+                for c in s
+                    if isspace(c)
+                        print(b, c)
+                        startword = true
+                    else
+                        print(b, startword ? titlecase(c) : c)
+                        startword = false
+                    end
                 end
+                return String(take!(b))
             end
-            return String(take!(b))
         end
     else
         using Unicode

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -752,13 +752,6 @@ end
     export BitSet
 end
 
-# 0.7.0-DEV.1930
-@static if !isdefined(Base, :textwidth)
-    textwidth(c::Char) = charwidth(c)
-    textwidth(c::AbstractString) = strwidth(c)
-    export textwidth
-end
-
 # 0.7.0-DEV.2116
 @static if VERSION < v"0.7.0-DEV.2116"
     import Base: spdiagm
@@ -872,6 +865,43 @@ end
 @static if !isdefined(Base, :ComplexF64)
     const ComplexF64 = Complex{Float64}
     export ComplexF64
+end
+
+# 0.7.0-DEV.2915
+module Unicode
+    export normalize, graphemes, isassigned, textwidth, isvalid,
+        islower, isupper, isalpha, isdigit, isxdigit, isnumeric, isalnum,
+        iscntrl, ispunct, isspace, isprint, isgraph,
+        lowercase, uppercase, titlecase, lcfirst, ucfirst
+
+    if VERSION < v"0.7.0-DEV.2915"
+        # 0.7.0-DEV.1930
+        if !isdefined(Base, :textwidth)
+            textwidth(c::Char) = charwidth(c)
+            textwidth(c::AbstractString) = strwidth(c)
+        end
+
+        isnumeric(c::Char) = isnumber(c)
+        titlecase(c::Char) = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
+            Char(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
+
+        function titlecase(s::AbstractString)
+            startword = true
+            b = IOBuffer()
+            for c in s
+                if isspace(c)
+                    print(b, c)
+                    startword = true
+                else
+                    print(b, startword ? titlecase(c) : c)
+                    startword = false
+                end
+            end
+            return String(take!(b))
+        end
+    else
+        using Unicode
+    end
 end
 
 include("deprecated.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -188,3 +188,7 @@ else
     import Base.@irrational
     import Base.LinAlg.BLAS.@blasfunc
 end
+
+if VERSION < v"0.7.0-DEV.2915"
+    Base.@deprecate textwidth Compat.Unicode.textwidth
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,10 +320,10 @@ let s = "Koala test: 🐨"
 end
 
 # julia#17155, tests from Base Julia
-@test (uppercase∘hex)(239487) == "3A77F"
+@test (Compat.Unicode.uppercase∘hex)(239487) == "3A77F"
 let str = randstring(20)
-    @test filter(!isupper, str) == replace(str, r"[A-Z]", "")
-    @test filter(!islower, str) == replace(str, r"[a-z]", "")
+    @test filter(!Compat.Unicode.isupper, str) == replace(str, r"[A-Z]", "")
+    @test filter(!Compat.Unicode.islower, str) == replace(str, r"[a-z]", "")
 end
 
 # julia#19950, tests from Base (#20028)
@@ -891,8 +891,8 @@ end
 @test 1 in BitSet(1:10)
 
 # 0.7.0-DEV.1930
-@test textwidth("A") == 1
-@test textwidth('A') == 1
+@test Compat.Unicode.textwidth("A") == 1
+@test Compat.Unicode.textwidth('A') == 1
 
 # 0.7
 @test diagm(0 => ones(2), -1 => ones(2)) == [1.0 0.0 0.0; 1.0 1.0 0.0; 0.0 1.0 0.0]
@@ -956,6 +956,18 @@ end
 @test ComplexF16 === Complex{Float16}
 @test ComplexF32 === Complex{Float32}
 @test ComplexF64 === Complex{Float64}
+
+# 0.7.0-DEV.2915
+module Test25021
+    using Compat
+    using Compat.Test
+    using Compat.Unicode
+    @test isdefined(@__MODULE__, :Unicode)
+
+    @test !isnumeric('a')
+    @test isnumeric('1')
+    @test titlecase("firstname lastname") == "Firstname Lastname"
+end
 
 if VERSION < v"0.6.0"
     include("deprecated.jl")


### PR DESCRIPTION
Changed in https://github.com/JuliaLang/julia/pull/25021. At the moment I disabled the OffsetArray tests as they cause the tests to fail on Julia 0.7.