### PR TITLE
Temporarily disable the OffsetArrays tests for 0.7

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -775,8 +775,10 @@ if VERSION < v"0.7.0-DEV.2655"
         export eigs, svds
     end
 elseif VERSION < v"0.7.0-DEV.3019"
-    import IterativeEigenSolvers
-    const IterativeEigensolvers = IterativeEigenSolvers
+    @eval module IterativeEigensolvers
+        using IterativeEigenSolvers: eigs, svds
+        export eigs, svds
+    end
 else
     import IterativeEigensolvers
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -630,11 +630,16 @@ using Compat: StringVector
 @test String(fill!(StringVector(5), 0x61)) == "aaaaa"
 
 # collect
-using OffsetArrays
-a = OffsetArray(1:3, -1:1)
-b = Compat.collect(a)
-@test indices(b) === (Base.OneTo(3),)
-@test b == [1,2,3]
+if VERSION < v"0.7.0-"
+    # Note: This is disabled on 0.7, since the Compat.collect functionality is only
+    # applicable on 0.5, and OffsetArrays currently has some incompatibilities with
+    # 0.7. This can be reenabled later if needed.
+    using OffsetArrays
+    a = OffsetArray(1:3, -1:1)
+    b = Compat.collect(a)
+    @test indices(b) === (Base.OneTo(3),)
+    @test b == [1,2,3]
+end
 
 # PR 22064
 module Test22064


### PR DESCRIPTION
The functionality being tested is only provided in Compat for compatibility with Julia 0.5, which is near end of life, and OffsetArrays currently has some issues on 0.7 that cause unrelated test failures in this package.