### PR TITLE
Undeprecate textwidth (only on Julia < 0.7-DEV.2915)

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -190,5 +190,6 @@ else
 end
 
 if VERSION < v"0.7.0-DEV.2915"
-    Base.@deprecate textwidth Compat.Unicode.textwidth
+    const textwidth = Compat.Unicode.textwidth
+    export textwidth
 end


### PR DESCRIPTION
That's a perfectly valid call on Julia 0.6, so it is annoying to make it
print warnings there suddenly for packages which previously worked fine.
Packages will progressively stop using it when being ported to 0.7: we
can simply rely on the deprecation provided by Julia itself.