### PR TITLE
Add CartesianIndices and LinearIndices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `replace` accepts a pair of pattern and replacement, with the number of replacements as
   a keyword argument ([#25165]).
 
+* `CartesianIndices` and `LinearIndices` types represent cartesian and linear indices of
+  an array (respectively), and indexing such objects allows translating from one kind of index
+  to the other ([#25113]).
+
 ## Renaming
 
 
@@ -431,3 +435,4 @@ includes this fix. Find the minimum version from there.
 [#25162]: https://github.com/JuliaLang/julia/issues/25162
 [#25165]: https://github.com/JuliaLang/julia/issues/25165
 [#25168]: https://github.com/JuliaLang/julia/issues/25168
+[#25113]: https://github.com/JuliaLang/julia/issues/25113

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1076,6 +1076,23 @@ end
 @test replace("abcb", "b"=>"c") == "accc"
 @test replace("abcb", "b"=>"c", count=1) == "accb"
 
+# 0.7.0-DEV.3025
+let c = CartesianIndices(1:3, 1:2), l = LinearIndices(1:3, 1:2)
+    @test LinearIndices(c) == collect(l)
+    @test CartesianIndices(l) == collect(c)
+    @test first(c) == CartesianIndex(1, 1)
+    @test CartesianIndex(1, 1) in c
+    @test first(l) == 1
+    @test size(c) == (3, 2)
+    @test c == collect(c) == [CartesianIndex(1, 1) CartesianIndex(1, 2)
+                              CartesianIndex(2, 1) CartesianIndex(2, 2)
+                              CartesianIndex(3, 1) CartesianIndex(3, 2)]
+    @test l == collect(l) == reshape(1:6, 3, 2)
+    @test c[1:6] == vec(c)
+    @test l == l[c] == map(i -> l[i], c)
+    @test l[vec(c)] == collect(1:6)
+end
+
 if VERSION < v"0.6.0"
     include("deprecated.jl")
 end


### PR DESCRIPTION
Needed in particular to get linear indices once `find` returns cartesian indices (https://github.com/JuliaLang/julia/pull/24774).

@timholy I couldn't find a simple way of reusing `CartesianRange` from Base since it had a very different structure on 0.6.
  