### PR TITLE
Add size(::LinearIndices)

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1376,6 +1376,7 @@ end
     # AbstractArray implementation
     Base.IndexStyle(::Type{LinearIndices{N,R}}) where {N,R} = IndexCartesian()
     Compat.axes(iter::LinearIndices{N,R}) where {N,R} = iter.indices
+    Base.size(iter::LinearIndices{N,R}) where {N,R} = length.(iter.indices)
     @inline function Base.getindex(iter::LinearIndices{N,R}, I::Vararg{Int, N}) where {N,R}
         dims = length.(iter.indices)
         #without the inbounds, this is slower than Base._sub2ind(iter.indices, I...)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1383,6 +1383,8 @@ end
         @inbounds result = reshape(1:prod(dims), dims)[(I .- first.(iter.indices) .+ 1)...]
         return result
     end
+elseif VERSION < v"0.7.0-DEV.3395"
+    Base.size(iter::LinearIndices{N,R}) where {N,R} = length.(iter.indices)
 end
 
 @static if !isdefined(Base, Symbol("@info"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1198,12 +1198,13 @@ let c = CartesianIndices(1:3, 1:2), l = LinearIndices(1:3, 1:2)
     @test first(c) == CartesianIndex(1, 1)
     @test CartesianIndex(1, 1) in c
     @test first(l) == 1
-    @test size(c) == (3, 2)
+    @test size(c) == size(l) == (3, 2)
     @test c == collect(c) == [CartesianIndex(1, 1) CartesianIndex(1, 2)
                               CartesianIndex(2, 1) CartesianIndex(2, 2)
                               CartesianIndex(3, 1) CartesianIndex(3, 2)]
     @test l == collect(l) == reshape(1:6, 3, 2)
     @test c[1:6] == vec(c)
+    @test l[1:6] == vec(l)
     @test l == l[c] == map(i -> l[i], c)
     @test l[vec(c)] == collect(1:6)
 end


### PR DESCRIPTION
Fixes indexing `LinearIndices` with an array. This is useful in particular to convert cartesian indices that `find` now returns to linear indices.

See https://github.com/JuliaLang/julia/pull/25541 (CI won't pass on 0.7 without it).