### PR TITLE
Fix `argmin`/`argmax` for non-vectors

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1311,8 +1311,17 @@ if !isdefined(Base, :findall)
 end
 
 @static if !isdefined(Base, :argmin)
-    const argmin = indmin
-    const argmax = indmax
+    if VERSION >= v"0.7.0-DEV.1660" # indmin/indmax return key
+        const argmin = indmin
+        const argmax = indmax
+    else
+        argmin(x::AbstractArray) = CartesianIndex(ind2sub(x, indmin(x)))
+        argmin(x::AbstractVector) = indmin(x)
+        argmin(x::Associative) = first(Iterators.drop(keys(x), indmin(values(x))-1))
+        argmax(x::AbstractArray) = CartesianIndex(ind2sub(x, indmax(x)))
+        argmax(x::AbstractVector) = indmax(x)
+        argmax(x::Associative) = first(Iterators.drop(keys(x), indmax(values(x))-1))
+    end
     export argmin, argmax
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1170,7 +1170,11 @@ end
 
 # 0.7.0-DEV.3516
 @test argmax([10,12,9,11]) == 2
+@test argmax([10 12; 9 11]) == CartesianIndex(1, 2)
+@test argmax(Dict(:z=>10, :y=>12, :x=>9, :w=>11)) == :y
 @test argmin([10,12,9,11]) == 3
+@test argmin([10 12; 9 11]) == CartesianIndex(2, 1)
+@test argmin(Dict(:z=>10, :y=>12, :x=>9, :w=>11)) == :x
 
 # 0.7.0-DEV.3415
 @test findall(x -> x==1, [1, 2, 3, 2, 1]) == [1, 5]


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/Compat.jl/pull/470#issuecomment-359798659.

I don't know whether there is a completely generic way of replicating the functionality on Julia 0.6, but I guess I have covered the most common cases.

CC @ararslan 