### PR TITLE
codeunits and ncodeunits

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Currently, the `@compat` macro supports the following syntaxes:
   an array (respectively), and indexing such objects allows translating from one kind of index
   to the other ([#25113]).
 
+* `codeunits(s)` returns an array-like view of the `UInt8` code units of
+  a string and `ncodeunits(s)` returns the number of code units ([#25241]).
+
 ## Renaming
 
 
@@ -483,6 +486,7 @@ includes this fix. Find the minimum version from there.
 [#25165]: https://github.com/JuliaLang/julia/issues/25165
 [#25168]: https://github.com/JuliaLang/julia/issues/25168
 [#25227]: https://github.com/JuliaLang/julia/issues/25227
+[#25241]: https://github.com/JuliaLang/julia/issues/25241
 [#25249]: https://github.com/JuliaLang/julia/issues/25249
 [#25402]: https://github.com/JuliaLang/julia/issues/25402
 [#25459]: https://github.com/JuliaLang/julia/issues/25459

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1334,6 +1334,13 @@ end
     export parentmodule
 end
 
+@static if !isdefined(Base, :codeunits)
+    codeunits(s::String) = Vector{UInt8}(s)
+    ncodeunits(s::Union{String,SubString{String}}) = sizeof(s)
+    codeunits(s::SubString{String}) = view(codeunits(s.string),1+s.offset:s.offset+sizeof(s))
+    export codeunits, ncodeunits
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,6 +1160,9 @@ end
 @test parentmodule(Int) == Core
 @test parentmodule(Array) == Core
 
+@test codeunits("foo") == [0x66,0x6f,0x6f] == codeunits(SubString("fooαβγ",1,3))
+@test ncodeunits("αβγ") == 6 == ncodeunits(SubString("fooαβγ",4,8))
+
 # 0.7.0-DEV.3382
 module TestLibdl
     using Compat


### PR DESCRIPTION
Added these functions from JuliaLang/julia#25241, which are especially useful for `Vector{UInt8}(string)` deprecations.

(See also JuliaIO/JSON.jl#234)