### PR TITLE
Use UniformScaling element type when constructing Matrix

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -902,10 +902,12 @@ end
 @static if VERSION < v"0.7.0-DEV.2377"
     (::Type{Matrix{T}}){T}(s::UniformScaling, dims::Dims{2}) = setindex!(zeros(T, dims), T(s.λ), diagind(dims...))
     (::Type{Matrix{T}}){T}(s::UniformScaling, m::Integer, n::Integer) = Matrix{T}(s, Dims((m, n)))
+    (::Type{Matrix})(s::UniformScaling, dims...) = Matrix{eltype(s)}(s, dims...)
 
     (::Type{SparseMatrixCSC{Tv,Ti}}){Tv,Ti}(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC{Tv,Ti}(s, Dims((m, n)))
     (::Type{SparseMatrixCSC{Tv}}){Tv}(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC{Tv}(s, Dims((m, n)))
     (::Type{SparseMatrixCSC{Tv}}){Tv}(s::UniformScaling, dims::Dims{2}) = SparseMatrixCSC{Tv,Int}(s, dims)
+    (::Type{SparseMatrixCSC})(s::UniformScaling, dims...) = SparseMatrixCSC{eltype(s),Int}(s, dims...)
     function (::Type{SparseMatrixCSC{Tv,Ti}}){Tv,Ti}(s::UniformScaling, dims::Dims{2})
         @boundscheck first(dims) < 0 && throw(ArgumentError("first dimension invalid ($(first(dims)) < 0)"))
         @boundscheck last(dims) < 0 && throw(ArgumentError("second dimension invalid ($(last(dims)) < 0)"))
@@ -921,6 +923,7 @@ end
 @static if VERSION < v"0.7.0-DEV.2543"
     (::Type{Array{T}}){T}(s::UniformScaling, dims::Dims{2}) = Matrix{T}(s, dims)
     (::Type{Array{T}}){T}(s::UniformScaling, m::Integer, n::Integer) = Matrix{T}(s, m, n)
+    (::Type{Array})(s::UniformScaling, dims...) = Matrix{eltype(s)}(s, dims...)
 end
 
 # https://github.com/JuliaLang/julia/pull/23271

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -969,12 +969,15 @@ end
 let a = [1 0 0; 0 1 0; 0 0 1]
     @test Matrix{Int}(I, 3, 3)::Matrix{Int} == a
     @test Matrix{Float64}(I, (3, 2))::Matrix{Float64} == a[:,1:2]
+    @test Matrix(1I, 3, 3)::Matrix{Int} == a
     @test Array{Int}(I, (3, 3))::Matrix{Int} == a
     @test Array{Float64}(I, 3, 2)::Matrix{Float64} == a[:,1:2]
+    @test Array(1.0I, (3, 3))::Matrix{Float64} == a
     @test SparseMatrixCSC{Int}(I, 3, 3)::SparseMatrixCSC{Int,Int} == a
     @test SparseMatrixCSC{Float64}(I, (3, 2))::SparseMatrixCSC{Float64,Int} == a[:,1:2]
     @test SparseMatrixCSC{Bool,Int16}(I, (3, 3))::SparseMatrixCSC{Bool,Int16} == a
     @test SparseMatrixCSC{ComplexF64,Int8}(I, 3, 2)::SparseMatrixCSC{ComplexF64,Int8} == a[:,1:2]
+    @test SparseMatrixCSC((1.0+0.0im)I, 3, 2)::SparseMatrixCSC{ComplexF64,Int} == a[:,1:2]
 end
 
 # 0.7.0-DEV.2581


### PR DESCRIPTION
This PR makes converting a `UniformScaling` to `Matrix` easier when you already have it setup with the correct type. For example, in v0.7 the following works:

```julia
julia> using LinearAlgebra

julia> cI = (1.0 + 0.0im)I
UniformScaling{Complex{Float64}}
(1.0 + 0.0im)*I

julia> Matrix(cI, 3, 3)
3×3 Array{Complex{Float64},2}:
 1.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  1.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  1.0+0.0im

julia> Matrix{Complex{Float64}}(I, 3, 3)
3×3 Array{Complex{Float64},2}:
 1.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  1.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  1.0+0.0im
```

whereas in v0.6 the type is mandatory:

```julia
julia> using Compat

julia> cI = (1.0+0.0im)I
UniformScaling{Complex{Float64}}
(1.0 + 0.0im)*I

julia> Matrix(cI, 3, 3)
ERROR: MethodError: no method matching Array{T,2} where T(::UniformScaling{Complex{Float64}}, ::Int64, ::Int64)
Closest candidates are:
  Array{T,2} where T(::Compat.Uninitialized, ::Any...) at string:5
  Array{T,2} where T(::Integer, ::Integer) at sysimg.jl:105
Stacktrace:
 [1] macro expansion at /home/justin/.julia/v0.6/Revise/src/Revise.jl:775 [inlined]
 [2] (::Revise.##17#18{Base.REPL.REPLBackend})() at ./event.jl:73

julia> Matrix{Complex{Float64}}(cI, 3, 3)
3×3 Array{Complex{Float64},2}:
 1.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  1.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  1.0+0.0im
```