### PR TITLE
Deprecation fixes and a few additions for 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `isabstract` and `isleaftype` are now `isabstracttype` and `isconcretetype`, respectively
   ([#23666], [#25496]).
 
+* `gc` and `gc_enable` are now `GC.gc` and `GC.enable`, respectively ([#25616]).
+
 ## New macros
 
 * `@__DIR__` has been added ([#18380])
@@ -503,6 +505,7 @@ includes this fix. Find the minimum version from there.
 [#25544]: https://github.com/JuliaLang/julia/issues/25544
 [#25545]: https://github.com/JuliaLang/julia/issues/25545
 [#25571]: https://github.com/JuliaLang/julia/issues/25571
+[#25616]: https://github.com/JuliaLang/julia/issues/25616
 [#25622]: https://github.com/JuliaLang/julia/issues/25622
 [#25628]: https://github.com/JuliaLang/julia/issues/25628
 [#25629]: https://github.com/JuliaLang/julia/issues/25629

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.isapprox` with `nans` keyword argument ([#20022])
 
-* `Compat.readline` with `chomp` keyword argument ([#20203])
+* `Compat.readline` with `keep` keyword argument ([#25646])
 
 * `take!` method for `Task`s since some functions now return `Channel`s instead of `Task`s ([#19841])
 
@@ -432,7 +432,6 @@ includes this fix. Find the minimum version from there.
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20022]: https://github.com/JuliaLang/julia/issues/20022
 [#20164]: https://github.com/JuliaLang/julia/issues/20164
-[#20203]: https://github.com/JuliaLang/julia/issues/20203
 [#20321]: https://github.com/JuliaLang/julia/issues/20321
 [#20407]: https://github.com/JuliaLang/julia/issues/20407
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
@@ -507,5 +506,6 @@ includes this fix. Find the minimum version from there.
 [#25622]: https://github.com/JuliaLang/julia/issues/25622
 [#25628]: https://github.com/JuliaLang/julia/issues/25628
 [#25629]: https://github.com/JuliaLang/julia/issues/25629
+[#25646]: https://github.com/JuliaLang/julia/issues/25646
 [#25654]: https://github.com/JuliaLang/julia/issues/25654
 [#24182]: https://github.com/JuliaLang/julia/issues/24182

--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ Currently, the `@compat` macro supports the following syntaxes:
   `MathConstants` module (available as `Compat.MathConstants`).
   The name exported from `Base` for `e` is changed to `ℯ`. ([#23427])
 
-* `isleaftype` is now `isconcrete` ([#23666])
-
 * `IntSet` is now `BitSet` ([#24282])
 
 * `Complex32`, `Complex64`, and `Complex128` are now `ComplexF16`, `ComplexF32`, and
@@ -317,6 +315,9 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `find` is now `findall` ([#25545]).
 
 * `indmin` and `indmax` are now `argmin` and `argmax`, respectively ([#25654]).
+
+* `isabstract` and `isleaftype` are now `isabstracttype` and `isconcretetype`, respectively
+  ([#23666], [#25496]).
 
 ## New macros
 
@@ -499,6 +500,7 @@ includes this fix. Find the minimum version from there.
 [#25249]: https://github.com/JuliaLang/julia/issues/25249
 [#25402]: https://github.com/JuliaLang/julia/issues/25402
 [#25459]: https://github.com/JuliaLang/julia/issues/25459
+[#25496]: https://github.com/JuliaLang/julia/issues/25496
 [#25544]: https://github.com/JuliaLang/julia/issues/25544
 [#25545]: https://github.com/JuliaLang/julia/issues/25545
 [#25571]: https://github.com/JuliaLang/julia/issues/25571

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `using Compat.Serialization` is provided on versions older than 0.7, where this library is
   not yet part of the standard library ([#25628]).
 
+* `using Compat.Distributed` is provided on versions older than 0.7, where this library is
+  not yet part of the standard library ([#24443]).
+
 ## New functions, macros, and methods
 
 * `@views` takes an expression and converts all slices to views ([#20164]), while
@@ -474,6 +477,7 @@ includes this fix. Find the minimum version from there.
 [#24282]: https://github.com/JuliaLang/julia/issues/24282
 [#24361]: https://github.com/JuliaLang/julia/issues/24361
 [#24372]: https://github.com/JuliaLang/julia/issues/24372
+[#24443]: https://github.com/JuliaLang/julia/issues/24443
 [#24459]: https://github.com/JuliaLang/julia/issues/24459
 [#24490]: https://github.com/JuliaLang/julia/issues/24490
 [#24605]: https://github.com/JuliaLang/julia/issues/24605

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -446,16 +446,11 @@ if VERSION < v"0.6.0-dev.1653"
     end
 end
 
-# https://github.com/JuliaLang/julia/pull/20203
-@static if VERSION < v"0.6.0-dev.2283"
+# https://github.com/JuliaLang/julia/pull/25646
+@static if VERSION < v"0.7.0-DEV.3510"
     # not exported
-    function readline(s::IO=STDIN; chomp::Bool=true)
-        if chomp
-            Base.chomp!(Base.readline(s))
-        else
-            Base.readline(s)
-        end
-    end
+    # chomp parameter preserved for compatibility with earliear Compat versions
+    readline(s::IO=STDIN; chomp::Bool=true, keep::Bool=!chomp) = Base.readline(s; chomp=!keep)
 end
 
 # https://github.com/JuliaLang/julia/pull/18727

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1476,6 +1476,15 @@ end
     export nameof
 end
 
+# 0.7.0-DEV.3469
+@static if !isdefined(Base, :GC)
+    @eval module GC
+        using Base: gc
+        const enable = Base.gc_enable
+    end
+    export GC
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1485,6 +1485,12 @@ end
     export GC
 end
 
+if VERSION < v"0.7.0-DEV.2954"
+    const Distributed = Base.Distributed
+else
+    import Distributed
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -391,18 +391,15 @@ else
     import Base.isapprox
 end
 
+@static if !isdefined(Base, :isabstracttype) # VERSION < v"0.7.0-DEV.3475"
+    const isabstracttype = Base.isabstract
+    export isabstracttype
+end
+
 module TypeUtils
-    @static if isdefined(Base, :isabstract)
-        using Base: isabstract, parameter_upper_bound, typename
-    else
-        isabstract(t::DataType) = t.abstract
-        if isdefined(Base, :TypeConstructor)
-            isabstract(t::TypeConstructor) = isabstract(t.body)
-        end
-        isabstract(t::ANY) = false
-        parameter_upper_bound(t::DataType, idx) = t.parameters[idx].ub
-        typename(t::DataType) = t.name
-    end
+    using Base: parameter_upper_bound, typename
+    using Compat: isabstracttype
+    const isabstract = isabstracttype
     export isabstract, parameter_upper_bound, typename
 end # module TypeUtils
 
@@ -740,10 +737,18 @@ if VERSION < v"0.7.0-DEV.1325"
     end
 end
 
-# 0.7.0-DEV.1775
-@static if !isdefined(Base, :isconcrete)
-    const isconcrete = isleaftype
-    export isconcrete
+
+# 0.7.0-DEV.3475
+@static if !isdefined(Base, :isconcretetype)
+    # 0.7.0-DEV.1775
+    @static if !isdefined(Base, :isconcrete)
+        const isconcretetype = isleaftype
+        const isconcrete = isleaftype # for compatibility with earlier Compat versions
+        export isconcrete
+    else
+        const isconcretetype = isconcrete
+    end
+    export isconcretetype
 end
 
 # 0.7.0-DEV.2005

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -170,7 +170,7 @@ end
     Base.@deprecate_binding UTF8String Core.String
     Base.@deprecate_binding ASCIIString Core.String
     Base.@deprecate_binding unsafe_convert Base.unsafe_convert
-    Base.@deprecate_binding remote_do Base.remote_do
+    Base.@deprecate_binding remote_do Distributed.remote_do
     Base.@deprecate_binding Filesystem Base.Filesystem
     Base.@deprecate_binding AsyncCondition Base.AsyncCondition
     Base.@deprecate_binding promote_eltype_op Base.promote_eltype_op

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,8 +318,8 @@ let s = "Koala test: 🐨"
     @test transcode(UInt32, s) == UInt32[75,111,97,108,97,32,116,101,115,116,58,32,128040]
     for T in (UInt8,UInt16,UInt32,Cwchar_t)
         @test transcode(Compat.String, transcode(T, s)) == s
-        @test transcode(UInt8, transcode(T, s)) == Vector{UInt8}(s)
-        @test transcode(T, s) == transcode(T, Vector{UInt8}(s)) == transcode(T, transcode(T, s))
+        @test transcode(UInt8, transcode(T, s)) == codeunits(s)
+        @test transcode(T, s) == transcode(T, codeunits(s)) == transcode(T, transcode(T, s))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -595,8 +595,8 @@ end
 
 # PR 20203
 @test Compat.readline(IOBuffer("Hello, World!\n")) == "Hello, World!"
-@test Compat.readline(IOBuffer("x\n"), chomp=true) == "x"
-@test Compat.readline(IOBuffer("x\n"), chomp=false) == "x\n"
+@test Compat.readline(IOBuffer("x\n"), keep=false) == "x"
+@test Compat.readline(IOBuffer("x\n"), keep=true) == "x\n"
 
 # PR 18727
 let

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1015,7 +1015,7 @@ let A = [1]
     finalize(A)
     @test x == 1
     A = 0
-    gc(); gc()
+    GC.gc(); GC.gc()
     @test x == 1
 end
 
@@ -1284,6 +1284,13 @@ module TestSerialization
     @test isdefined(@__MODULE__, :deserialize)
     @test isdefined(@__MODULE__, :SerializationState)
 end
+
+# 0.7.0-DEV.3469
+@test GC.enable(true)
+@test GC.enable(false)
+@test !GC.enable(false)
+@test !GC.enable(true)
+@test GC.enable(true)
 
 if VERSION < v"0.6.0"
     include("deprecated.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -901,10 +901,12 @@ module Test23876
     using Compat.Test
     import Compat.DelimitedFiles
     using Compat.Mmap, Compat.SharedArrays
+    using Compat.Distributed
     @test isdefined(@__MODULE__, :DelimitedFiles)
     @test isdefined(SharedArrays, :SharedArray)
     @test isdefined(@__MODULE__, :SharedArray)
     @test isdefined(@__MODULE__, :procs)
+    @test isdefined(@__MODULE__, :remote_do)
     @test isdefined(Mmap, :mmap)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -722,9 +722,9 @@ for T in (Float64, ComplexF32, BigFloat, Int)
 end
 
 let
-    @compat cr(::CartesianRange{2}) = 2
-    @test cr(CartesianRange((5, 3))) == 2
-    @test_throws MethodError cr(CartesianRange((5, 3, 2)))
+    @compat cr(::CartesianIndices{2}) = 2
+    @test cr(CartesianIndices((5, 3))) == 2
+    @test_throws MethodError cr(CartesianIndices((5, 3, 2)))
 end
 if VERSION < v"0.7.0-DEV.880"
     # ensure we don't bork any non-updated expressions
@@ -776,7 +776,7 @@ end
 
 let
     A14 = [11 13; 12 14]
-    R = CartesianRange(Compat.axes(A14))
+    R = CartesianIndices(Compat.axes(A14))
     @test [a for (a,b) in pairs(IndexLinear(),    A14)] == [1,2,3,4]
     @test [a for (a,b) in pairs(IndexCartesian(), A14)] == vec(collect(R))
     @test [b for (a,b) in pairs(IndexLinear(),    A14)] == [11,12,13,14]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1064,8 +1064,8 @@ end
 # 0.7.0-DEV.3017
 @test isa(Some(1), Some{Int})
 @test convert(Some{Float64}, Some(1)) == Some(1.0)
-@test convert(Void, nothing) == nothing
-@test_throws MethodError convert(Void, 1)
+@test convert(Nothing, nothing) == nothing
+@test_throws MethodError convert(Nothing, 1)
 @test Some(nothing) != nothing
 @test coalesce(Some(1)) == 1
 @test coalesce(nothing) == nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -776,7 +776,7 @@ end
 
 let
     A14 = [11 13; 12 14]
-    R = CartesianRange(indices(A14))
+    R = CartesianRange(Compat.axes(A14))
     @test [a for (a,b) in pairs(IndexLinear(),    A14)] == [1,2,3,4]
     @test [a for (a,b) in pairs(IndexCartesian(), A14)] == vec(collect(R))
     @test [b for (a,b) in pairs(IndexLinear(),    A14)] == [11,12,13,14]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,6 +390,11 @@ eval(Expr(
 @test !Compat.TypeUtils.isabstract(StridedArray)
 @test Compat.TypeUtils.parameter_upper_bound(ConcreteFoo20006, 1) == Int
 @test isa(Compat.TypeUtils.typename(Array), TypeName)
+@test isabstracttype(AbstractFoo20006)
+@test !isabstracttype(ConcreteFoo20006)
+@test !isabstracttype(ConcreteFoo20006N)
+@test !isabstracttype(ConcreteFoo200061)
+@test !isabstracttype(StridedArray)
 
 # @view and @views tests copied from Base
 let X = reshape(1:24,2,3,4), Y = 4:-1:1
@@ -888,7 +893,7 @@ if VERSION >= v"0.6"
 end
 
 # 0.7
-@test isconcrete(Int)
+@test isconcretetype(Int)
 
 # 0.7
 module Test23876

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,8 +326,8 @@ end
 # julia#17155, tests from Base Julia
 @test (Compat.Unicode.uppercase∘hex)(239487) == "3A77F"
 let str = "aBcDeFgHiJ"
-    @test filter(!Compat.Unicode.isupper, str) == replace(str, r"[A-Z]", "")
-    @test filter(!Compat.Unicode.islower, str) == replace(str, r"[a-z]", "")
+    @test filter(!Compat.Unicode.isupper, str) == replace(str, r"[A-Z]" => "")
+    @test filter(!Compat.Unicode.islower, str) == replace(str, r"[a-z]" => "")
 end
 
 # julia#19950, tests from Base (#20028)


### PR DESCRIPTION
A grab-bag of deprecation fixes:

* For some, I just needed to use existing Compat functionality in the tests. 
* I added `GC`, `Distributed`, and `isabstracttype`/`isconcretetype`.
* I reworked `readline` to accept `keep`.

For the latter two, I preserved the existing behavior (`isconcrete` instead of `isconcretetype` and `chomp` keyword for `readline`) for downstream compatibility, but removed the docs.

The remaining warnings are now:
* Output from stuff deprecated inside Compat, where the output redirection does not work anymore with the new logging infrastructure.
* And this, where I'd really appreciate better location info:
```
┌ Warning: the behavior of `A[I...] .= X` with scalar indices will change in the future. Use `A[I...] = X` instead.
│   caller = ip:0x0
└ @ Core :-1
```