### PR TITLE
Add `lastindex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `gc` and `gc_enable` are now `GC.gc` and `GC.enable`, respectively ([#25616]).
 
+* `endof` is now `lastindex` ([#25458]). (Note that `lastindex(A, n)` is not supported.)
+
 ## New macros
 
 * `@__DIR__` has been added ([#18380])
@@ -504,6 +506,7 @@ includes this fix. Find the minimum version from there.
 [#25241]: https://github.com/JuliaLang/julia/issues/25241
 [#25249]: https://github.com/JuliaLang/julia/issues/25249
 [#25402]: https://github.com/JuliaLang/julia/issues/25402
+[#25458]: https://github.com/JuliaLang/julia/issues/25458
 [#25459]: https://github.com/JuliaLang/julia/issues/25459
 [#25496]: https://github.com/JuliaLang/julia/issues/25496
 [#25544]: https://github.com/JuliaLang/julia/issues/25544

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1491,6 +1491,12 @@ else
     import Distributed
 end
 
+# 0.7.0-DEV.3583
+@static if !isdefined(Base, :lastindex)
+    const lastindex = endof
+    export lastindex
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1294,6 +1294,10 @@ end
 @test !GC.enable(true)
 @test GC.enable(true)
 
+# 0.7.0-DEV.3583
+@test lastindex(zeros(4)) == 4
+@test lastindex(zeros(4,4)) == 16
+
 if VERSION < v"0.6.0"
     include("deprecated.jl")
 end


### PR DESCRIPTION
Where not provided by Julia, it is just defined as an alias for `endof`, hence does not support `lastindex(A, n)`, as `endof` doesn't.