### PR TITLE
rename reprmime and mimewritable

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Display` is now `AbstractDisplay` ([#24831]).
 
+* `reprmime(mime, x)` is now `repr(mime, x)` ([#25990]) and `mimewritable` is now `showable` ([#26089]).
+
 * `$` is now `xor` or `⊻` ([#18977])
 
 * `num` and `den` are now `numerator` and `denominator` ([#19246])
@@ -566,3 +568,5 @@ includes this fix. Find the minimum version from there.
 [#25738]: https://github.com/JuliaLang/julia/issues/25738
 [#25780]: https://github.com/JuliaLang/julia/issues/25780
 [#25819]: https://github.com/JuliaLang/julia/issues/25819
+[#25990]: https://github.com/JuliaLang/julia/issues/25990
+[#26089]: https://github.com/JuliaLang/julia/issues/26089

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1643,6 +1643,15 @@ else
     findall(b::OccursIn, a::Number) = a in b.x ? [1] : Vector{Int}()
 end
 
+@static if VERSION < v"0.7.0-DEV.4047" #26089
+    showable(mime, x) = mimewritable(mime, x)
+    export showable
+end
+
+@static if VERSION < v"0.7.0-DEV.4010" #25990
+    Base.repr(mime::Union{AbstractString,MIME}, x) = reprmime(mime, x)
+end
+
 # https://github.com/JuliaLang/julia/pull/25647
 @static if VERSION < v"0.7.0-DEV.3526"
     names(m; all=true, imported=true) = Base.names(m, all, imported)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1413,6 +1413,9 @@ end
 import Compat.Markdown
 @test isa(Markdown.parse("foo"), Markdown.MD)
 
+@test repr("text/plain", "string") == "\"string\"" #25990
+@test showable("text/plain", 3.14159) #26089
+
 # 0.7.0-DEV.3526
 module TestNames
     export foo


### PR DESCRIPTION
This PR implements the renames `reprmime` -> `repr` (JuliaLang/julia#25990) and `mimewritable` -> `showable` (JuliaLang/julia#26089).

JuliaLang/julia#25990 also moved `stringmime` into the `Base64` package, but `Compat.Base64.stringmime` should work as-is.

(In 0.7, `repr` also supports a new `context` keyword, but that feature is not implemented by this PR.)