### PR TITLE
Compat.IOBuffer bugfixes

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1567,29 +1567,49 @@ end
 
 # https://github.com/JuliaLang/julia/pull/25872
 if VERSION < v"0.7.0-DEV.3734"
+    if isdefined(Base, :open_flags)
+        import Base.open_flags
+    else
+        # copied from Base:
+        function open_flags(; read=nothing, write=nothing, create=nothing, truncate=nothing, append=nothing)
+            if write === true && read !== true && append !== true
+                create   === nothing && (create   = true)
+                truncate === nothing && (truncate = true)
+            end
+            if truncate === true || append === true
+                write  === nothing && (write  = true)
+                create === nothing && (create = true)
+            end
+            write    === nothing && (write    = false)
+            read     === nothing && (read     = !write)
+            create   === nothing && (create   = false)
+            truncate === nothing && (truncate = false)
+            append   === nothing && (append   = false)
+            return (read, write, create, truncate, append)
+        end
+    end
     function IOBuffer(
             data::Union{AbstractVector{UInt8},Nothing}=nothing;
-            read::Union{Bool,Nothing}=nothing,
-            write::Union{Bool,Nothing}=nothing,
-            truncate::Union{Bool,Nothing}=nothing,
+            read::Union{Bool,Nothing}=data===nothing?true:nothing,
+            write::Union{Bool,Nothing}=data===nothing?true:nothing,
+            truncate::Union{Bool,Nothing}=data===nothing?true:nothing,
             maxsize::Integer=typemax(Int),
             sizehint::Union{Integer,Nothing}=nothing)
-        write    === nothing && (write    = false)
-        read     === nothing && (read     = !write)
-        truncate === nothing && (truncate = false)
+        flags = open_flags(read=read, write=write, append=nothing, truncate=truncate)
         if maxsize < 0
             throw(ArgumentError("negative maxsize: $(maxsize)"))
         end
-        if sizehint !== nothing
-            sizehint!(data, sizehint)
-        end
-        buf = if data !== nothing
-            Base.IOBuffer(data, read, write, Int(maxsize))
+        if data !== nothing
+            if sizehint !== nothing
+                sizehint!(data, sizehint)
+            end
+            buf = Base.IOBuffer(data, flags[1], flags[2], Int(maxsize))
         else
-            size = maxsize == typemax(Int) ? 32 : Int(maxsize)
-            Base.IOBuffer(StringVector(size), read, write, Int(maxsize))
+            size = sizehint !== nothing ? Int(sizehint) : maxsize != typemax(Int) ? Int(maxsize) : 32
+            buf = Base.IOBuffer(StringVector(size), flags[1], flags[2], Int(maxsize))
+            buf.data[:] = 0
         end
-        if truncate
+        if flags[4] # flags.truncate
             buf.size = 0
         end
         return buf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1438,5 +1438,13 @@ let buf = Compat.IOBuffer(read=true, write=false, maxsize=25)
     @test !buf.writable
     @test buf.maxsize == 25
 end
+let buf = Compat.IOBuffer(zeros(UInt8, 4), write=true) # issue #502
+    write(buf, 'a')
+    @test take!(buf) == [0x61]
+end
+let buf = Compat.IOBuffer(sizehint=20)
+    println(buf, "Hello world.")
+    @test String(take!(buf)) == "Hello world.\n"
+end
 
 nothing


### PR DESCRIPTION
Fixes some bugs in #501: incorrect handling of `sizehint` when `data===nothing` and incorrect logic for the `truncate` flag (#502).