### PR TITLE
use Base.prod() when computing length(::CartesianIndices)

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1285,7 +1285,7 @@ end
     size(iter::CartesianIndices) = map(dimlength, first(iter).I, last(iter).I)
     dimlength(start, stop) = stop-start+1
 
-    length(iter::CartesianIndices) = prod(size(iter))
+    length(iter::CartesianIndices) = Base.prod(size(iter))
 
     first(iter::CartesianIndices) = CartesianIndex(map(first, iter.indices))
     last(iter::CartesianIndices)  = CartesianIndex(map(last, iter.indices))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1668,5 +1668,9 @@ end
 @test Compat.reverse([1, 2, 3, 4]) == [4, 3, 2, 1]
 @test Compat.reverse([1 2; 3 4], dims=1) == [3 4; 1 2]
 @test Compat.reverse([1 2; 3 4], dims=2) == [2 1; 4 3]
+# Issue #523
+@test length(Compat.CartesianIndices((1:1,))) == 1
+@test length(Compat.CartesianIndices((1:2,))) == 2
+@test length(Compat.CartesianIndices((1:2, -1:1))) == 6
 
 nothing


### PR DESCRIPTION
Fixes #523 

I also added a test for that `length()` method and put it with the rest of the #518 tests. 