### PR TITLE
Add  `squeeze` with `dims` as keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `selectdim` to obtain a view of an array with a specified index for a specified dimension ([#26009]).
 
+* `squeeze` with `dims` as keyword argument ([#26660]).
+
 ## Renaming
 
 * `Display` is now `AbstractDisplay` ([#24831]).
@@ -618,3 +620,4 @@ includes this fix. Find the minimum version from there.
 [#26369]: https://github.com/JuliaLang/julia/issues/26369
 [#26436]: https://github.com/JuliaLang/julia/issues/26436
 [#26442]: https://github.com/JuliaLang/julia/issues/26442
+[#26660]: https://github.com/JuliaLang/julia/issues/26660

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1777,6 +1777,9 @@ if VERSION < v"0.7.0-DEV.4534"
     reverse(a::AbstractArray; dims=nothing) =
         dims===nothing ? Base.reverse(a) : Base.flipdim(a, dims)
 end
+if VERSION < v"0.7.0-DEV.4738"
+    Base.squeeze(A; dims=error("squeeze: keyword argument dims not assigned")) = squeeze(A, dims)
+end
 
 if !isdefined(Base, :selectdim) # 0.7.0-DEV.3976
     export selectdim

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1678,6 +1678,7 @@ end
 @test_throws ArgumentError squeeze([1 2], dims=2)
 @test_throws ArgumentError squeeze(hcat([1, 2]), dims=1)
 @test squeeze(hcat([1, 2]), dims=2) == [1, 2]
+@test_throws Exception squeeze([1,2])
 
 # 0.7.0-DEV.3976
 let A = rand(5,5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1673,6 +1673,12 @@ end
 @test length(Compat.CartesianIndices((1:2,))) == 2
 @test length(Compat.CartesianIndices((1:2, -1:1))) == 6
 
+# 0.7.0-DEV.4738
+@test squeeze([1 2], dims=1) == [1, 2]
+@test_throws ArgumentError squeeze([1 2], dims=2)
+@test_throws ArgumentError squeeze(hcat([1, 2]), dims=1)
+@test squeeze(hcat([1, 2]), dims=2) == [1, 2]
+
 # 0.7.0-DEV.3976
 let A = rand(5,5)
     @test selectdim(A, 1, 3) == A[3, :]


### PR DESCRIPTION
Contrary to all the other methods that got the `dims` keyword, this one can safely extend the Base function because `squeeze(A)` is not defined.