### PR TITLE
`digits` as keyword argument for `round` and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.range` supporting keyword arguments ([#25896]).
 
-* `Compat.trunc`, `Compat.floor`, `Compat.ceil`, `Compat.round`, `Compat.signif` take a keyword argument for `base` ([#26156]).
+* `Compat.trunc`, `Compat.floor`, `Compat.ceil`, `Compat.round`, take a keyword argument
+  for `base` and `digits`, `Compat.round` also takes `sigdigits` ([#26156], [#26670]).
 
 * `Compat.mv` and `Compat.cp` with `force` keyword argument ([#26069]).
 
@@ -618,3 +619,4 @@ includes this fix. Find the minimum version from there.
 [#26369]: https://github.com/JuliaLang/julia/issues/26369
 [#26436]: https://github.com/JuliaLang/julia/issues/26436
 [#26442]: https://github.com/JuliaLang/julia/issues/26442
+[#26670]: https://github.com/JuliaLang/julia/issues/26670

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1592,13 +1592,53 @@ else
     end
 end
 
-# https://github.com/JuliaLang/julia/pull/26156
+# https://github.com/JuliaLang/julia/pull/26670
 @static if VERSION < v"0.7.0-DEV.4062"
-    trunc(x, digits; base = base) = Base.trunc(x, digits, base)
-    floor(x, digits; base = base) = Base.floor(x, digits, base)
-    ceil(x, digits; base = base) = Base.ceil(x, digits, base)
-    round(x, digits; base = base) = Base.round(x, digits, base)
-    signif(x, digits; base = base) = Base.signif(x, digits, base)
+    trunc(x; digits = digits, base = base) = Base.trunc(x, digits, base)
+    floor(x; digits = digits, base = base) = Base.floor(x, digits, base)
+    ceil(x; digits = digits, base = base) = Base.ceil(x, digits, base)
+    function round(x; digits = nothing, sigdigits = nothing, base = base)
+        if digits === nothing
+            if sigdigits === nothing
+                Base.round(x, 0, base)
+            else
+                Base.signif(x, sigdigits, base)
+            end
+        else
+            sigdigits === nothing || throw(AgrumentError("`round` cannot use both `digits` and `sigdigits` arguments"))
+            Base.round(x, digits, base)
+        end
+    end
+elseif VERSION < v"0.7.0-DEV.4804"
+    trunc(x; digits = digits, base = base) = Base.trunc(x, digits, base = base)
+    floor(x; digits = digits, base = base) = Base.floor(x, digits, base = base)
+    ceil(x; digits = digits, base = base) = Base.ceil(x, digits, base = base)
+    function round(x; digits = nothing, sigdigits = nothing, base = base)
+        if digits === nothing
+            if sigdigits === nothing
+                Base.round(x, 0, base = base)
+            else
+                Base.signif(x, sigdigits, base = base)
+            end
+        else
+            sigdigits === nothing || throw(AgrumentError("`round` cannot use both `digits` and `sigdigits` arguments"))
+            Base.round(x, digits, base = base)
+        end
+    end
+else
+    trunc(x; digits = digits, base = base) = Base.trunc(x, digits = digits, base = base)
+    floor(x; digits = digits, base = base) = Base.floor(x, digits = digits, base = base)
+    ceil(x; digits = digits, base = base) = Base.ceil(x, digits = digits, base = base)
+    round(x; digits = nothing, sigdigits = nothing, base = base) = Base.round(x, digits = digits, sigdigits = sigdigits, base = base)
+end
+
+# compatibiltiy with https://github.com/JuliaLang/julia/pull/26156
+if VERSION < v"0.7.0-DEV.4062" || VERSION >= v"0.7.0-DEV.4804"
+    trunc(x, digits; base = base) = trunc(x, digits = digits, base = base)
+    floor(x, digits; base = base) = floor(x, digits = digits, base = base)
+    ceil(x, digits; base = base) = ceil(x, digits = digits, base = base)
+    round(x, digits; base = base) = round(x, digits = digits, base = base)
+    signif(x, digits; base = base) = round(x, sigdigits = digits, base = base)
 end
 
 # https://github.com/JuliaLang/julia/pull/25872

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1472,12 +1472,19 @@ end
 @test :foo in Compat.names(TestNames)
 @test :bar in Compat.names(TestNames, all=true)
 
-# 0.7.0-DEV.4062
+# 0.7.0-DEV.4062, but dropped in 0.7.0-DEV.4804
 @test Compat.trunc(pi, 3, base = 2) == 3.125
 @test Compat.floor(pi, 3, base = 2) == 3.125
 @test Compat.ceil(pi, 3, base = 2) == 3.25
 @test Compat.round(pi, 3, base = 2) == 3.125
-@test Compat.signif(pi, 5, base = 2) == 3.125
+@test Compat.signif(pi, 5, base = 10) == 3.1416
+
+# 0.7.0-DEV.4804
+@test Compat.trunc(pi, digits = 3, base = 2) == 3.125
+@test Compat.floor(pi, digits = 3, base = 2) == 3.125
+@test Compat.ceil(pi, digits = 3, base = 2) == 3.25
+@test Compat.round(pi, digits = 3, base = 2) == 3.125
+@test Compat.round(pi, sigdigits = 5, base = 10) == 3.1416
 
 # 0.7.0-DEV.3734
 let buf = Compat.IOBuffer(read=true, write=false, maxsize=25)


### PR DESCRIPTION
Add `digits` as keyword argument to `trunc`, `floor`, `ceil`, and `round`. Also add `sigdigits` as keyword argument to `round`.

I've kept the old methods that take `digits` as a positional argument. Or should I rather deprecate or remove them?

Note: CI failure on nightly is expected pending https://github.com/JuliaLang/Compat.jl/pull/529, but the relevant tests pass locally.