### PR TITLE
Teach selectdim that its slices are slices

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1780,7 +1780,7 @@ end
 
 if !isdefined(Base, :selectdim) # 0.7.0-DEV.3976
     export selectdim
-    @inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, Base.setindex(axes(A), i, d))
+    @inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, Base.setindex(map(Base.Slice, axes(A)), i, d))
     @noinline function _selectdim(A, d, i, idxs)
         d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
         nd = ndims(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1681,6 +1681,13 @@ let A = rand(5,5)
     @test selectdim(A, 2, 1:3) == A[:, 1:3]
     selectdim(A, 1, 3)[3] = 42
     @test A[3,3] == 42
+    if VERSION < v"0.7.0-DEV.3976" || VERSION >= v"0.7.0-DEV.4739"
+        # in the omitted version range, Julia's selectdim always gives IndexCartesian()
+        B = rand(4, 3, 2)
+        @test IndexStyle(selectdim(B, 1, 1)) == IndexStyle(view(B, 1, :, :)) == IndexLinear()
+        @test IndexStyle(selectdim(B, 2, 1)) == IndexStyle(view(B, :, 1, :)) == IndexCartesian()
+        @test IndexStyle(selectdim(B, 3, 1)) == IndexStyle(view(B, :, :, 1)) == IndexLinear()
+    end
 end
 
 nothing


### PR DESCRIPTION
... as done in JuliaLang/julia#26655. (Ref. https://github.com/JuliaLang/Compat.jl/pull/522#issuecomment-377383541)

Note that for `v"0.7.0-DEV.3976" <= VERSION < v"0.7.0-DEV.4739"`, we don't define our own `selectdim` but the Julia one doesn't do the slice thing. Conceivably, we could define an unexported `selectdim` in this version range, but I don't think it's worth it.