### PR TITLE
Add `qr` with `pivot` as `Val` instance and `full` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `squeeze` with `dims` as keyword argument ([#26660]).
 
+* `Compat.qr` takes `pivot` as a `Val` _instance_ and keyword argument `full` ([#22475], [#24279]).
+
 ## Renaming
 
 * `Display` is now `AbstractDisplay` ([#24831]).
@@ -552,6 +554,7 @@ includes this fix. Find the minimum version from there.
 [#23931]: https://github.com/JuliaLang/julia/issues/23931
 [#24047]: https://github.com/JuliaLang/julia/issues/24047
 [#24182]: https://github.com/JuliaLang/julia/issues/24182
+[#24279]: https://github.com/JuliaLang/julia/issues/24279
 [#24282]: https://github.com/JuliaLang/julia/issues/24282
 [#24361]: https://github.com/JuliaLang/julia/issues/24361
 [#24372]: https://github.com/JuliaLang/julia/issues/24372

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1830,6 +1830,18 @@ if !isdefined(Base, :selectdim) # 0.7.0-DEV.3976
     end
 end
 
+if VERSION < v"0.7.0-DEV.2337"
+    if VERSION < v"0.7.0-DEV.843"
+        qr(A::Union{Number,AbstractMatrix}, pivot::Union{Val{false},Val{true}}=Val(false); full=false) =
+            Base.qr(A, typeof(pivot), thin=!full)
+    else
+        qr(A::Union{Number,AbstractMatrix}, pivot::Union{Val{false},Val{true}}=Val(false); full=false) =
+            Base.qr(A, pivot, thin=!full)
+    end
+else
+    using LinearAlgebra: qr
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1705,4 +1705,26 @@ let A = rand(5,5)
     end
 end
 
+# 0.7.0-DEV.843 / 0.7.0-DEV.2337
+let A = [1 2; 1 2; 1 2]
+    f = Compat.qr(A, Val(false), full=false)
+    @test f == Compat.qr(A, Val(false))
+    @test length(f) == 2
+    @test size(f[1]) == (3, 2)
+    @test f[1] * f[2] ≈ A
+    f = Compat.qr(A, Val(false), full=true)
+    @test length(f) == 2
+    @test size(f[1]) == (3, 3)
+    @test f[1] * [f[2]; [0 0]] ≈ A
+    f = Compat.qr(A, Val(true), full=false)
+    @test f == Compat.qr(A, Val(true))
+    @test length(f) == 3
+    @test size(f[1]) == (3, 2)
+    @test f[1] * f[2] ≈ A[:,f[3]]
+    f = Compat.qr(A, Val(true), full=true)
+    @test length(f) == 3
+    @test size(f[1]) == (3, 3)
+    @test f[1] * [f[2]; [0 0]] ≈ A[:,f[3]]
+end
+
 nothing


### PR DESCRIPTION
Test pass locally on 0.7 when commenting out the (unrelatedly) failing tests (see #529).