### PR TITLE
import serialize_type into Compat.Serialization

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -861,7 +861,7 @@ end
 
 if VERSION < v"0.7.0-DEV.3476"
     @eval module Serialization
-        import Base.Serializer: serialize, deserialize, SerializationState
+        import Base.Serializer: serialize, deserialize, SerializationState, serialize_type
         export serialize, deserialize, SerializationState
     end
 else


### PR DESCRIPTION
A lot of packages need the non-exported function `Serializer.serialize_type` in order to extend the `serialize` function to new types, so Compat needs to import this.