### PR TITLE
Export isnumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `cfunction` is now `@cfunction` ([#26486]).
 
+* `Unicode.isnumeric` is now available as `isnumeric` ([#25479]).
+
 ## New macros
 
 * `@__DIR__` has been added ([#18380])
@@ -595,6 +597,7 @@ includes this fix. Find the minimum version from there.
 [#25402]: https://github.com/JuliaLang/julia/issues/25402
 [#25458]: https://github.com/JuliaLang/julia/issues/25458
 [#25459]: https://github.com/JuliaLang/julia/issues/25459
+[#25479]: https://github.com/JuliaLang/julia/issues/25479
 [#25496]: https://github.com/JuliaLang/julia/issues/25496
 [#25522]: https://github.com/JuliaLang/julia/issues/25522
 [#25544]: https://github.com/JuliaLang/julia/issues/25544

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1084,6 +1084,12 @@ module Unicode
     end
 end
 
+# 0.7.0-DEV.3393
+@static if VERSION < v"0.7.0-DEV.3393"
+    import .Unicode.isnumeric
+    export isnumeric
+end
+
 # 0.7.0-DEV.2951
 @static if !isdefined(Base, :AbstractDict)
     const AbstractDict = Associative

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1022,6 +1022,10 @@ module Test25021
     @test Compat.Unicode.normalize("\t\r", stripcc=true) == "  "
 end
 
+# 0.7.0-DEV.3393
+@test !isnumeric('a')
+@test isnumeric('1')
+
 # 0.7.0-DEV.2951
 @test AbstractDict === (isdefined(Base, :AbstractDict) ? Base.AbstractDict : Base.Associative)
 


### PR DESCRIPTION
`isnumeric` is now exported from Base. https://github.com/JuliaLang/julia/pull/25479