### PR TITLE
RFC: Remove obsolete custom Iterators module

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## Module Aliases
 
-* In 0.6, some 0.5 iterator functions have been moved to the `Base.Iterators`
-  module. Code can be written to work on both 0.5 and 0.6 by `import`ing or
-  `using` the `Compat.Iterators` module instead. ([#18839])
-
 * `using Compat.Test`, `using Compat.SharedArrays`, `using Compat.Mmap`, and `using
   Compat.DelimitedFiles` are provided on versions older than 0.7, where these are not yet
   part of the standard library. ([#23931])

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -321,24 +321,7 @@ end # module TypeUtils
 include("arraymacros.jl")
 
 # julia #18839
-if VERSION < v"0.6.0-dev.1024"
-    @eval module Iterators
-        export countfrom, cycle, drop, enumerate, flatten, product, repeated,
-               rest, take, zip, partition
-
-        import Base: eltype, start, next, done, length, size, ndims
-        using Base: tuple_type_cons
-        using Base: countfrom, cycle, drop, enumerate, repeated, rest, take,
-                    zip
-        using Compat
-
-        using Base: flatten
-        using Base: product
-        using Base: partition
-    end
-else
-    using Base.Iterators
-end
+import Base.Iterators # TODO deprecate, remove
 
 @static if VERSION < v"0.6.0-dev.2840"
     export IndexStyle, IndexLinear, IndexCartesian

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -523,30 +523,6 @@ end
 @test isbits(Primitive20418{Int})
 @test sizeof(Primitive20418{Int}) == 2
 
-# julia #18839
-module Test18839
-
-using Compat
-using Compat.Iterators
-using Compat.Test
-
-@test collect(take(countfrom(2), 3)) == [2, 3, 4]
-@test collect(take(cycle(5:8), 9)) == [5:8; 5:8; 5]
-@test collect(drop([1, 2, 3], 2)) == [3]
-@test collect(enumerate([4, 5, 6])) == [(1,4), (2,5), (3,6)]
-@test collect(flatten(Any[1:2, 4:5, Any[-1, 4]])) == [1,2,4,5,-1,4]
-@test vec(collect(product([1, 2], [3, 4]))) == [(1,3), (2,3), (1,4), (2,4)]
-@test vec(collect(product(1:2, 1:2, 1:2))) == [
-    (1,1,1), (2,1,1), (1,2,1), (2,2,1),
-    (1,1,2), (2,1,2), (1,2,2), (2,2,2)]
-@test collect(take(repeated(10), 5)) == [10,10,10,10,10]
-@test collect(rest(1:10, 5)) == [5,6,7,8,9,10]
-@test collect(take([1, 2, 3], 2)) == [1, 2]
-@test collect(zip([1,2], [3,4])) == [(1,3), (2,4)]
-@test collect(partition(1:5, 2)) == Any[[1,2],[3,4],[5]]
-
-end
-
 # PR #20500
 @compat A20500{T<:Integer} = Array{T,20500}
 @compat const A20500_2{T<:Union{Int,Float32}} = Pair{T,T}


### PR DESCRIPTION
Our tests have started failing because
```julia
julia> @test collect(rest(1:10, 5)) == [5,6,7,8,9,10]
Test Failed at REPL[13]:1
  Expression: collect(rest(1:10, 5)) == [5, 6, 7, 8, 9, 10]
   Evaluated: [6, 7, 8, 9, 10] == [5, 6, 7, 8, 9, 10]
```
the state for iterating over a range has changed its meaning. (Arguably, it's a bad idea to depend on the meaning of iteration state like that.)

As on all supported Julia versions, we just load `Base.Iterators`, there is no point in defining our own module, and then I hope we can just remove all those tests instead of developing elaborate alternatives.

There is a twist: We've been `using Base.Iterators` (if present), meaning that e.g. `Compat.zip(...)` would have worked, but only since Julia 0.6, where `Iterators.zip(...)` without any `Compat` worked just as well. Anyone actually aiming at compatibility with Julia 0.5 had to use `Compat.Iterators`, so I guess switching from `using` to `import` here should not break anyones code. At some point, we should also deprecate that binding, but I'm not sure whether that point is now.