### PR TITLE
Remove Dates comparison code which has been in Base since 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.StringVector` is supported on 0.5 and below. On 0.6 and later, it aliases `Base.StringVector`. This function allocates a `Vector{UInt8}` whose data can be made into a `String` in constant time; that is, without copying. On 0.5 and later, use `String(...)` with the vector allocated by `StringVector` as an argument to create a string without copying. Note that if 0.4 support is needed, `Compat.UTF8String(...)` should be used instead. ([#19449])
 
-* `==(::Period, ::Period)` and `isless(::Period, ::Period)` is supported for 0.5 and below. Earlier versions of Julia only supported limited comparison methods between Periods which did not support comparing custom Period subtypes. ([#21378])
-
 * `@__MODULE__` is aliased to `current_module()` for Julia versions 0.6 and below. Versions of `Base.binding_module`, `expand`, `macroexpand`, and `include_string` were added that accept a module as the first argument. ([#22064])
 
 * `Cmd` elements can be accessed as if the `Cmd` were an array of strings for 0.6 and below ([#21197]).
@@ -535,7 +533,6 @@ includes this fix. Find the minimum version from there.
 [#21197]: https://github.com/JuliaLang/julia/issues/21197
 [#21257]: https://github.com/JuliaLang/julia/issues/21257
 [#21346]: https://github.com/JuliaLang/julia/issues/21346
-[#21378]: https://github.com/JuliaLang/julia/issues/21378
 [#21419]: https://github.com/JuliaLang/julia/issues/21419
 [#21709]: https://github.com/JuliaLang/julia/issues/21709
 [#22064]: https://github.com/JuliaLang/julia/issues/22064

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -438,20 +438,6 @@ if VERSION < v"0.7.0-DEV.257"
     end
 end
 
-# https://github.com/JuliaLang/julia/pull/21378
-if VERSION < v"0.6.0-pre.beta.455"
-    import Base: ==, isless
-
-    ==(x::Dates.Period, y::Dates.Period) = (==)(promote(x, y)...)
-    isless(x::Dates.Period, y::Dates.Period) = isless(promote(x,y)...)
-
-    # disallow comparing fixed to other periods
-    ==(x::Dates.FixedPeriod, y::Dates.OtherPeriod) = throw(MethodError(==, (x, y)))
-    ==(x::Dates.OtherPeriod, y::Dates.FixedPeriod) = throw(MethodError(==, (x, y)))
-    isless(x::Dates.FixedPeriod, y::Dates.OtherPeriod) = throw(MethodError(isless, (x, y)))
-    isless(x::Dates.OtherPeriod, y::Dates.FixedPeriod) = throw(MethodError(isless, (x, y)))
-end
-
 # https://github.com/JuliaLang/julia/pull/22475
 @static if VERSION < v"0.7.0-DEV.843"
     import Base: Val

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -677,32 +677,6 @@ let foo() = begin
     @test foo() == 2
 end
 
-# PR 21378
-let
-    import Compat: Dates
-
-    # https://en.wikipedia.org/wiki/Swatch_Internet_Time
-    eval(Expr(
-        struct_sym, false,
-        Expr(:(<:), :Beat, :(Dates.Period)),
-        quote
-            value::Int64
-        end))
-
-    Dates.value(b::Beat) = b.value
-    Dates.toms(b::Beat) = Dates.value(b) * 86400
-    Dates._units(b::Beat) = " beat" * (abs(Dates.value(b)) == 1 ? "" : "s")
-    Base.promote_rule(::Type{Dates.Day}, ::Type{Beat}) = Dates.Millisecond
-    Base.convert(::Type{Dates.Millisecond}, b::Beat) = Dates.Millisecond(Dates.toms(b))
-
-    @test Beat(1000) == Dates.Day(1)
-    @test Beat(1) < Dates.Day(1)
-    @test_throws MethodError Dates.Day(30) == Dates.Month(1)
-    @test_throws MethodError Dates.Month(1) == Dates.Day(30)
-    @test_throws MethodError Dates.Day(1) < Dates.Month(1)
-    @test_throws MethodError Dates.Month(1) < Dates.Day(1)
-end
-
 # PR #21197
 let c = `ls -l "foo bar"`
     @test collect(c) == ["ls", "-l", "foo bar"]


### PR DESCRIPTION
The behavior of `==(x::Dates.FixedPeriod, y::Dates.OtherPeriod)` has been changed in https://github.com/JuliaLang/julia/pull/27165, making our tests fail. As the relevant code is no longer needed on 0.6 or later, I figured we could just delete the tests as well.

Note: This leaves the difference for `==(x::Dates.FixedPeriod, y::Dates.OtherPeriod)` between 0.6 and 0.7. If we need a Compat for that, I'd suggest opening a separate PR.