### PR TITLE
Don't test that `Pkg` exports `add`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1275,7 +1275,7 @@ module TestPkg
     using Compat.Pkg
     using Compat.Test
     @test isdefined(@__MODULE__, :Pkg)
-    @test isdefined(@__MODULE__, :add)
+    @test isdefined(Compat.Pkg, :add)
 end
 
 module TestInteractiveUtils


### PR DESCRIPTION
Pkg3 still defines `add`, but doesn't export it anymore.

Minor follow-up to #551.