### PR TITLE
Neither advertise the functions moved to StatsBase nor test them on 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.mv` and `Compat.cp` with `force` keyword argument ([#26069]).
 
-* `Compat.accumulate`, `Compat.accumulate!`, `Compat.all`, `Compat.any`, `Compat.cor`,
-  `Compat.cov`, `Compat.cumprod`, `Compat.cumprod!`, `Compat.cumsum`, `Compat.cumsum!`,
+* `Compat.accumulate`, `Compat.accumulate!`, `Compat.all`, `Compat.any`,
+  `Compat.cumprod`, `Compat.cumprod!`, `Compat.cumsum`, `Compat.cumsum!`,
   `Compat.findmax`, `Compat.findmin`, `Compat.mapreduce`, `Compat.maximum`, `Compat.mean`,
   `Compat.median`, `Compat.minimum`, `Compat.prod`, `Compat.reduce`, `Compat.sort`,
-  `Compat.std`, `Compat.sum`, `Compat.var`, and `Compat.varm` with `dims` keyword argument ([#25989],[#26369]).
+  and `Compat.sum`  with `dims` keyword argument ([#25989],[#26369]).
 
 * `selectdim` to obtain a view of an array with a specified index for a specified dimension ([#26009]).
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -500,6 +500,7 @@ if VERSION < v"0.7.0-DEV.755"
     # This is a hack to only add keyword signature that won't work on all julia versions.
     # However, since we really only need to support a few (0.5, 0.6 and early 0.7) versions
     # this should be good enough.
+    # TODO add deprecation warning to switch to StatsBase
     let Tf = typeof(Base.cov), Tkw = Core.Core.kwftype(Tf)
         @eval begin
             @inline function _get_corrected(kws)
@@ -1760,6 +1761,7 @@ if VERSION < v"0.7.0-DEV.4064"
             end
         end
     end
+    # TODO add deprecation warning to switch to StatsBase to var and std
     for f in (:var, :std, :sort)
         @eval begin
             $f(a::AbstractArray; dims=nothing, kwargs...) =
@@ -1772,6 +1774,7 @@ if VERSION < v"0.7.0-DEV.4064"
     end
 end
 if VERSION < v"0.7.0-DEV.4064"
+    # TODO add deprecation warning to switch to StatsBase to varm, cov, and cor
     varm(A::AbstractArray, m; dims=nothing, kwargs...) =
         dims===nothing ? Base.varm(A, m; kwargs...) : Base.varm(A, m, dims; kwargs...)
     if VERSION < v"0.7.0-DEV.755"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -834,11 +834,13 @@ end
 @test Base.rtoldefault(Float64, Float64, 1.0) === 0.0
 
 # 0.7
-@test cov([1 2; 3 4], 1, corrected=true) == fill(2.0, 2, 2)
-@test cov([1 2; 3 4], 1, corrected=false) == fill(1.0, 2, 2)
-@test cov([1 2; 3 4], [0 4; 8 9], 1, corrected=true) == [8.0 5.0; 8.0 5.0]
-@test cov([1 2; 3 4], [0 4; 8 9], 1, corrected=false) == [4.0 2.5; 4.0 2.5]
-if VERSION >= v"0.6"
+if VERSION  < v"0.7.0-DEV.5238"
+    # Test the extended cov if cov is part of Base. In the future, this will be dealt with
+    # in StatsBase
+    @test cov([1 2; 3 4], 1, corrected=true) == fill(2.0, 2, 2)
+    @test cov([1 2; 3 4], 1, corrected=false) == fill(1.0, 2, 2)
+    @test cov([1 2; 3 4], [0 4; 8 9], 1, corrected=true) == [8.0 5.0; 8.0 5.0]
+    @test cov([1 2; 3 4], [0 4; 8 9], 1, corrected=false) == [4.0 2.5; 4.0 2.5]
     @test cov([1, 2], corrected=true) === 0.5
     @test cov([1, 2], corrected=false) === 0.25
     @test cov([1, 2], [0, 10], corrected=true) === 5.0
@@ -1569,36 +1571,40 @@ Issue26488 && @test Compat.prod(x -> x+1, [1 2; 3 4], dims=2) == hcat([6; 20])
 @test Compat.findmin([1 2; 3 4]) == (1, CartesianIndex(1, 1))
 @test Compat.findmin([1 2; 3 4], dims=1) == ([1 2], [CartesianIndex(1, 1) CartesianIndex(1, 2)])
 @test Compat.findmin([1 2; 3 4], dims=2) == (hcat([1; 3]), hcat([CartesianIndex(1, 1); CartesianIndex(2, 1)]))
-@test Compat.varm([1 2; 3 4], -1) == 18
-@test Compat.varm([1 2; 3 4], [-1 -2], dims=1) == [20 52]
-@test Compat.varm([1 2; 3 4], [-1, -2], dims=2) == hcat([13, 61])
-@test Compat.var([1 2; 3 4]) == 5/3
-@test Compat.var([1 2; 3 4], dims=1) == [2 2]
-@test Compat.var([1 2; 3 4], dims=2) == hcat([0.5, 0.5])
-@test Compat.var([1 2; 3 4], corrected=false) == 1.25
-@test Compat.var([1 2; 3 4], corrected=false, dims=1) == [1 1]
-@test Compat.var([1 2; 3 4], corrected=false, dims=2) == hcat([0.25, 0.25])
-@test Compat.std([1 2; 3 4]) == sqrt(5/3)
-@test Compat.std([1 2; 3 4], dims=1) == [sqrt(2) sqrt(2)]
-@test Compat.std([1 2; 3 4], dims=2) == hcat([sqrt(0.5), sqrt(0.5)])
-@test Compat.std([1 2; 3 4], corrected=false) == sqrt(1.25)
-@test Compat.std([1 2; 3 4], corrected=false, dims=1) == [sqrt(1) sqrt(1)]
-@test Compat.std([1 2; 3 4], corrected=false, dims=2) == hcat([sqrt(0.25), sqrt(0.25)])
-@test Compat.cov([1 2; 3 4]) == [2 2; 2 2]
-@test Compat.cov([1 2; 3 4], dims=1) == [2 2; 2 2]
-@test Compat.cov([1 2; 3 4], dims=2) == [0.5 0.5; 0.5 0.5]
-@test Compat.cov([1 2; 3 4], [4; 5]) == hcat([1; 1])
-@test Compat.cov([1 2; 3 4], [4; 5], dims=1) == hcat([1; 1])
-@test Compat.cov([1 2; 3 4], [4; 5], dims=2) == hcat([0.5; 0.5])
-@test Compat.cov([1 2; 3 4], [4; 5], corrected=false) == hcat([0.5; 0.5])
-@test Compat.cov([1 2; 3 4], [4; 5], corrected=false, dims=1) == hcat([0.5; 0.5])
-@test Compat.cov([1 2; 3 4], [4; 5], corrected=false, dims=2) == hcat([0.25; 0.25])
-@test Compat.cor([1 2; 3 4]) ≈ [1 1; 1 1]
-@test Compat.cor([1 2; 3 4], dims=1) ≈ [1 1; 1 1]
-@test Compat.cor([1 2; 3 4], dims=2) ≈ [1 1; 1 1]
-@test Compat.cor([1 2; 3 4], [4; 5]) ≈ [1; 1]
-@test Compat.cor([1 2; 3 4], [4; 5], dims=1) ≈ [1; 1]
-@test Compat.cor([1 2; 3 4], [4; 5], dims=2) ≈ [1; 1]
+if VERSION  < v"0.7.0-DEV.5238"
+    # Test these functions if their counterparts are defined in Base. In the future, this
+    # will be dealt with in StatsBase
+    @test Compat.varm([1 2; 3 4], -1) == 18
+    @test Compat.varm([1 2; 3 4], [-1 -2], dims=1) == [20 52]
+    @test Compat.varm([1 2; 3 4], [-1, -2], dims=2) == hcat([13, 61])
+    @test Compat.var([1 2; 3 4]) == 5/3
+    @test Compat.var([1 2; 3 4], dims=1) == [2 2]
+    @test Compat.var([1 2; 3 4], dims=2) == hcat([0.5, 0.5])
+    @test Compat.var([1 2; 3 4], corrected=false) == 1.25
+    @test Compat.var([1 2; 3 4], corrected=false, dims=1) == [1 1]
+    @test Compat.var([1 2; 3 4], corrected=false, dims=2) == hcat([0.25, 0.25])
+    @test Compat.std([1 2; 3 4]) == sqrt(5/3)
+    @test Compat.std([1 2; 3 4], dims=1) == [sqrt(2) sqrt(2)]
+    @test Compat.std([1 2; 3 4], dims=2) == hcat([sqrt(0.5), sqrt(0.5)])
+    @test Compat.std([1 2; 3 4], corrected=false) == sqrt(1.25)
+    @test Compat.std([1 2; 3 4], corrected=false, dims=1) == [sqrt(1) sqrt(1)]
+    @test Compat.std([1 2; 3 4], corrected=false, dims=2) == hcat([sqrt(0.25), sqrt(0.25)])
+    @test Compat.cov([1 2; 3 4]) == [2 2; 2 2]
+    @test Compat.cov([1 2; 3 4], dims=1) == [2 2; 2 2]
+    @test Compat.cov([1 2; 3 4], dims=2) == [0.5 0.5; 0.5 0.5]
+    @test Compat.cov([1 2; 3 4], [4; 5]) == hcat([1; 1])
+    @test Compat.cov([1 2; 3 4], [4; 5], dims=1) == hcat([1; 1])
+    @test Compat.cov([1 2; 3 4], [4; 5], dims=2) == hcat([0.5; 0.5])
+    @test Compat.cov([1 2; 3 4], [4; 5], corrected=false) == hcat([0.5; 0.5])
+    @test Compat.cov([1 2; 3 4], [4; 5], corrected=false, dims=1) == hcat([0.5; 0.5])
+    @test Compat.cov([1 2; 3 4], [4; 5], corrected=false, dims=2) == hcat([0.25; 0.25])
+    @test Compat.cor([1 2; 3 4]) ≈ [1 1; 1 1]
+    @test Compat.cor([1 2; 3 4], dims=1) ≈ [1 1; 1 1]
+    @test Compat.cor([1 2; 3 4], dims=2) ≈ [1 1; 1 1]
+    @test Compat.cor([1 2; 3 4], [4; 5]) ≈ [1; 1]
+    @test Compat.cor([1 2; 3 4], [4; 5], dims=1) ≈ [1; 1]
+    @test Compat.cor([1 2; 3 4], [4; 5], dims=2) ≈ [1; 1]
+end
 @test Compat.median([1 2; 3 4]) == 2.5
 @test Compat.median([1 2; 3 4], dims=1) == [2 3]
 @test Compat.median([1 2; 3 4], dims=2) == hcat([1.5; 3.5])


### PR DESCRIPTION
These functions call through to Base functions, which is rendered impossible after their moval to StatsBase (JuliaLang/julia#27152). As StatsBase is using Compat, Compat cannot use StatsBase. In the future, these functions should print deprecation warnings also on 0.6, telling people how to get the desired functionality, once that is settled (see discussion in https://github.com/JuliaStats/StatsBase.jl/pull/379).

Alternatively, we could duplicate the code now moved to StatsBase in Compat.