### PR TITLE
Fix test deprecations on 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `Compat.rmul!` provides a subset of the functionality of `LinearAlgebra.rmul!` for
   use with Julia 0.6 ([#25701], [#25812]).
 
+* `isbits(t::Type)` is now `isbitstype(t)` ([#26850]).
+
 ## Renaming
 
 * `Display` is now `AbstractDisplay` ([#24831]).
@@ -630,4 +632,5 @@ includes this fix. Find the minimum version from there.
 [#26442]: https://github.com/JuliaLang/julia/issues/26442
 [#26660]: https://github.com/JuliaLang/julia/issues/26660
 [#26670]: https://github.com/JuliaLang/julia/issues/26670
+[#26850]: https://github.com/JuliaLang/julia/issues/26850
 [#27077]: https://github.com/JuliaLang/julia/issues/27077

--- a/README.md
+++ b/README.md
@@ -167,11 +167,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 * `transcode` converts between UTF-xx string encodings in Julia 0.5 (as a lightweight
    alternative to the LegacyStrings package) ([#17323])
 
-* `∘` (typically used infix as `f ∘ g`) for function composition can be used in 0.5 and earlier ([#17155])
-
 * `>:`, a supertype operator for symmetry with `issubtype` (`A >: B` is equivalent to `B <: A`), can be used in 0.5 and earlier ([#20407]).
-
-* The method of `!` to negate functions (typically used as a unary operator, as in `!isinteger`) can be used in 0.5 and earlier ([#17155]).
 
 * `iszero(x)` efficiently checks whether `x == zero(x)` (including arrays) can be used in 0.5 and earlier ([#19950]).
 
@@ -500,7 +496,6 @@ includes this fix. Find the minimum version from there.
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#16564]: https://github.com/JuliaLang/julia/issues/16564
 [#16986]: https://github.com/JuliaLang/julia/issues/16986
-[#17155]: https://github.com/JuliaLang/julia/issues/17155
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
 [#17510]: https://github.com/JuliaLang/julia/issues/17510

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1863,6 +1863,12 @@ end
     const isletter = isalpha
 end
 
+# https://github.com/JuliaLang/julia/pull/26850
+if !isdefined(Base, :isbitstype) # 0.7.0-DEV.4905
+    export isbitstype
+    isbitstype(::Type{T}) where {T} = isbits(T)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -281,14 +281,6 @@ if VERSION < v"0.6.0-dev.1256"
     Base.take!(io::Base.AbstractIOBuffer) = takebuf_array(io)
 end
 
-# julia #17155 function composition and negation
-@static if VERSION < v"0.6.0-dev.1883"
-    export ∘
-    ∘(f, g) = (x...)->f(g(x...))
-    @compat Base.:!(f::Function) = (x...)->!f(x...)
-end
-
-
 if VERSION < v"0.6.0-dev.1632"
     # To work around unsupported syntax on Julia 0.4
     include_string("export .&, .|")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -427,7 +427,7 @@ let X = reshape(1:24,2,3,4), Y = 4:-1:1
         @test isa(x[1:3],SubArray)
         @test x[2] === 11
         @test Dict((1:3) => 4)[1:3] === 4
-        x[1:2] = 0
+        x[1:2] .= 0
         @test x == [0,0,19,4]
         x[1:2] .= 5:6
         @test x == [5,6,19,4]
@@ -435,7 +435,7 @@ let X = reshape(1:24,2,3,4), Y = 4:-1:1
         @test x == [5,6,35,4]
         x[Y[2:3]] .= 7:8
         @test x == [5,8,7,4]
-        @dotcompat x[(3,)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
+        @dotcompat x[([3],)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
         @test x == [5,8,10,4]
         i = Int[]
         # test that lhs expressions in update operations are evaluated only once:
@@ -454,7 +454,7 @@ let X = reshape(1:24,2,3,4), Y = 4:-1:1
         @test isa(x[1:3],SubArray)
         @test x[2] === 11
         @test Dict((1:3) => 4)[1:3] === 4
-        x[1:2] = 0
+        x[1:2] .= 0
         @test x == [0,0,19,4]
         x[1:2] .= 5:6
         @test x == [5,6,19,4]
@@ -462,7 +462,7 @@ let X = reshape(1:24,2,3,4), Y = 4:-1:1
         @test x == [5,6,35,4]
         x[Y[2:3]] .= 7:8
         @test x == [5,8,7,4]
-        @dotcompat x[(3,)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
+        @dotcompat x[([3],)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
         @test x == [5,8,10,4]
         i = Int[]
         # test that lhs expressions in update operations are evaluated only once:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1165,7 +1165,7 @@ for p in [Compat.Dates.Year, Compat.Dates.Month]
 end
 
 # 0.7.0-DEV.3025
-let c = CartesianIndices(1:3, 1:2), l = LinearIndices(1:3, 1:2)
+let c = CartesianIndices((1:3, 1:2)), l = LinearIndices((1:3, 1:2))
     @test LinearIndices(c) == collect(l)
     @test CartesianIndices(l) == collect(c)
     @test first(c) == CartesianIndex(1, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,7 +513,7 @@ end
 @test Compat.TypeUtils.isabstract(Abstract20418)
 @compat primitive type Primitive20418{T} <: Ref{T} 16 end
 @test !Compat.TypeUtils.isabstract(Primitive20418)
-@test isbits(Primitive20418{Int})
+@test isbitstype(Primitive20418{Int})
 @test sizeof(Primitive20418{Int}) == 2
 
 # PR #20500
@@ -1724,5 +1724,9 @@ end
 @test isletter('a')
 @test isletter('β')
 @test !isletter('3')
+
+# 0.7.0-DEV.4905
+@test isbitstype(Int)
+@test !isbitstype(Vector{Int})
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1076,8 +1076,8 @@ end
 @test occursin('W', "Hello, World!")
 
 # 0.7.0-DEV.3449
-let A = [2.0 1.0; 1.0 3.0], b = [1.0, 2.0], x = [0.2, 0.6]
-    @test cholfact(A) \ b ≈ x
+let A = [2.0 1.0; 1.0 3.0], b = [2.0, 3.0]
+    @test diag(A) == b
 end
 
 # 0.7.0-DEV.3173

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,13 +323,6 @@ let s = "Koala test: 🐨"
     end
 end
 
-# julia#17155, tests from Base Julia
-@test (Compat.Unicode.uppercase∘hex)(239487) == "3A77F"
-let str = "aBcDeFgHiJ"
-    @test filter(!Compat.Unicode.isupper, str) == replace(str, r"[A-Z]" => "")
-    @test filter(!Compat.Unicode.islower, str) == replace(str, r"[a-z]" => "")
-end
-
 # julia#19950, tests from Base (#20028)
 for T in (Float16, Float32, Float64, BigFloat, Int8, Int16, Int32, Int64, Int128,
           BigInt, UInt8, UInt16, UInt32, UInt64, UInt128)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1113,7 +1113,7 @@ x = Compat.Dates.Second(172799)
 @test round(x, Compat.Dates.Second) == Compat.Dates.Second(172799)
 @test round(x, Compat.Dates.Millisecond) == Compat.Dates.Millisecond(172799000)
 
-x = Dates.Nanosecond(2000999999)
+x = Compat.Dates.Nanosecond(2000999999)
 @test floor(x, Compat.Dates.Second) == Compat.Dates.Second(2)
 @test floor(x, Compat.Dates.Millisecond) == Compat.Dates.Millisecond(2000)
 @test floor(x, Compat.Dates.Microsecond) == Compat.Dates.Microsecond(2000999)
@@ -1144,7 +1144,7 @@ x = Compat.Dates.Hour(36)
 @test_throws DomainError round(x, Compat.Dates.Day, RoundNearest)
 @test_throws DomainError round(x, Compat.Dates.Day, RoundNearestTiesAway)
 @test_throws DomainError round(x, Compat.Dates.Day, RoundToZero)
-@test round(x, Dates.Day) == round(x, Compat.Dates.Day, RoundNearestTiesUp)
+@test round(x, Compat.Dates.Day) == round(x, Compat.Dates.Day, RoundNearestTiesUp)
 
 x = Compat.Dates.Hour(86399)
 for p in [Compat.Dates.Week, Compat.Dates.Day, Compat.Dates.Hour, Compat.Dates.Second, Compat.Dates.Millisecond, Compat.Dates.Microsecond, Compat.Dates.Nanosecond]


### PR DESCRIPTION
Look ma, no more deprecation warnings! (For the moment, that is.)

Mainly, this updates test syntax.
Exceptions:
* It removes  function composition and negation with ∘ and ! (now obsolete, part of Base since 0.6).
* It introduces `isbitstype`, as it was needed for a test.