### PR TITLE
Fixes for 0.7-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `reshape` and `ntuple` APIs are extended to support `Val{x}()` arguments on 0.6 and below.
 
-* `chol` and `chol!` for `UniformScalings` ([#22633]).
-
 * `logdet` for `Number`s ([#22629]).
 
 * `fieldcount` is equivalent to `nfields` for Julia versions 0.6 and below and is used to
@@ -540,7 +538,6 @@ includes this fix. Find the minimum version from there.
 [#22475]: https://github.com/JuliaLang/julia/issues/22475
 [#22512]: https://github.com/JuliaLang/julia/issues/22512
 [#22629]: https://github.com/JuliaLang/julia/issues/22629
-[#22633]: https://github.com/JuliaLang/julia/issues/22633
 [#22646]: https://github.com/JuliaLang/julia/issues/22646
 [#22666]: https://github.com/JuliaLang/julia/issues/22666
 [#22751]: https://github.com/JuliaLang/julia/issues/22751

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1100,29 +1100,15 @@ end
 
 @static if !isdefined(Base, :Some)
     import Base: promote_rule, convert
-    if VERSION >= v"0.6.0"
-        include_string(@__MODULE__, """
-            struct Some{T}
-                value::T
-            end
-            promote_rule(::Type{Some{S}}, ::Type{Some{T}}) where {S,T} = Some{promote_type(S, T)}
-            promote_rule(::Type{Some{T}}, ::Type{Nothing}) where {T} = Union{Some{T}, Nothing}
-            convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))
-            convert(::Type{Union{Some{T}, Nothing}}, x::Some) where {T} = convert(Some{T}, x)
-            convert(::Type{Union{T, Nothing}}, x::Any) where {T} = convert(T, x)
-        """)
-    else
-        include_string(@__MODULE__, """
-            immutable Some{T}
-                value::T
-            end
-            promote_rule{S,T}(::Type{Some{S}}, ::Type{Some{T}}) = Some{promote_type(S, T)}
-            promote_rule{T}(::Type{Some{T}}, ::Type{Nothing}) = Union{Some{T}, Nothing}
-            convert{T}(::Type{Some{T}}, x::Some) = Some{T}(convert(T, x.value))
-            convert{T}(::Type{Union{Some{T}, Nothing}}, x::Some) = convert(Some{T}, x)
-            convert{T}(::Type{Union{T, Nothing}}, x::Any) = convert(T, x)
-        """)
+    struct Some{T}
+        value::T
     end
+    promote_rule(::Type{Some{T}}, ::Type{Some{S}}) where {T,S<:T} = Some{T}
+    promote_rule(::Type{Some{T}}, ::Type{Nothing}) where {T} = Union{Some{T}, Nothing}
+    convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))
+    convert(::Type{Union{Some{T}, Nothing}}, x::Some) where {T} = convert(Some{T}, x)
+
+    convert(::Type{Union{T, Nothing}}, x::Any) where {T} = convert(T, x)
     convert(::Type{Nothing}, x::Any) = throw(MethodError(convert, (Nothing, x)))
     convert(::Type{Nothing}, x::Nothing) = nothing
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1125,6 +1125,9 @@ end
     end
     convert(::Type{Nothing}, x::Any) = throw(MethodError(convert, (Nothing, x)))
     convert(::Type{Nothing}, x::Nothing) = nothing
+
+    # Note: this is the definition of coalasce prior to 0.7.0-DEV.5278; kept to avoid
+    # breakage in packages already using it
     coalesce(x::Any) = x
     coalesce(x::Some) = x.value
     coalesce(x::Nothing) = nothing
@@ -1133,6 +1136,7 @@ end
     coalesce(x::Some, y...) = x.value
     coalesce(x::Nothing, y...) = coalesce(y...)
     #coalesce(x::Union{Nothing, Missing}, y...) = coalesce(y...)
+
     notnothing(x::Any) = x
     notnothing(::Nothing) = throw(ArgumentError("nothing passed to notnothing"))
     export Some, coalesce

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -432,6 +432,8 @@ end
 
 # https://github.com/JuliaLang/julia/pull/22633
 if VERSION < v"0.7.0-DEV.1041"
+    # these have been deprecated in Julia 0.7.0-DEV.5272; we keep them here to avoid
+    # breakage in packages already using them on Julia 0.6
     import Base.LinAlg: chol, chol!
     chol!(J::UniformScaling, uplo) = UniformScaling(chol!(J.λ, uplo))
     chol(J::UniformScaling, args...) = UniformScaling(chol(J.λ, args...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1044,9 +1044,12 @@ end
 @test convert(Nothing, nothing) == nothing
 @test_throws MethodError convert(Nothing, 1)
 @test Some(nothing) != nothing
-@test coalesce(Some(1)) == 1
-@test coalesce(nothing) == nothing
-@test coalesce(nothing, Some(1), Some(2)) == 1
+if VERSION < v"0.7.0-DEV.5278"
+    # coalesce has changed; old behavior kept and tested to avoid accidental breakage
+    @test coalesce(Some(1)) == 1
+    @test coalesce(nothing) == nothing
+    @test coalesce(nothing, Some(1), Some(2)) == 1
+end
 @test Compat.notnothing(1) == 1
 @test_throws ArgumentError Compat.notnothing(nothing)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -668,10 +668,14 @@ end
 @test logdet(0.5) == log(det(0.5))
 
 # PR 22633
-for T in (Float64, ComplexF32, BigFloat, Int)
-    λ = T(4)
-    @test chol(λ*I).λ ≈ √λ
-    @test_throws Union{ArgumentError,Compat.LinearAlgebra.PosDefException} chol(-λ*I)
+if VERSION < v"0.7.0-DEV.5272"
+    # chol(A::UniformScaling) has been deprecated in Julia, we still test it to avoid
+    # accidental breakage in packages using the Compat vesion of it on Julia 0.6
+    for T in (Float64, ComplexF32, BigFloat, Int)
+        λ = T(4)
+        @test chol(λ*I).λ ≈ √λ
+        @test_throws Union{ArgumentError,Compat.LinearAlgebra.PosDefException} chol(-λ*I)
+    end
 end
 
 let


### PR DESCRIPTION
This deals with the latest changes in Base in the conservative way: stop testing here on newer Julia, but keep them around on Julia 0.6. This affects `chol(::UniformScaling)` which will keep working on 0.6 but gives a deprecation warning on 0.7 with a replacement also suitable for 0.7. So no harm here, people can adjust their code and we may or may not deprecate/remove that `chol` definition eventually.

More troublesome is `coalesce`, which has changed its meaning. Following the brief discussion in #562, I've kept its old meaning here, but only on older Julia, and therefore also `VERSION`-gated the tests. Fortunately, it is not mentioned in the README, so hopefully, its uses are rare. Summary of main differences:

expression| 0.6 (with Compat) | 0.7
--|--|--
`coalesce(nothing, Some(1))` | `1` | `nothing`
`coalesce(Some(1), nothing)` | `1` | `Some(1)`

In 0.7, `coalesce` is for working with `missing`, which doesn't exist in 0.6 (and there is no Compat for it, either), so people should switch to using `something` to be added in #562.
I'm open to deprecating `coalesce` in Compat in favor of `something`. But I'd like to keep this PR focused on fixing the existing test failures, and let a potentially long discussion about a better way forward happen somewhere else.

That said, I've sneaked in a tiny breaking change to the promotion rules of `Some` which I hope not to have any significant impact on existing code.