### PR TITLE
Add `Compat.readuntil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.eachline` with `keep` keyword argument ([#25646])
 
+* `Compat.readuntil` with `keep` keyword argument ([#25646])
+
 * `take!` method for `Task`s since some functions now return `Channel`s instead of `Task`s ([#19841])
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -283,6 +283,18 @@ end
     # chomp parameter preserved for compatibility with earliear Compat versions
     readline(s::IO=STDIN; chomp::Bool=true, keep::Bool=!chomp) = Base.readline(s; chomp=!keep)
     eachline(s; keep::Bool=false) = Base.eachline(s; chomp=!keep)
+
+    stripdelim(s, d::Union{Char,UInt8}) = s[end] == Char(d) ? s[1:prevind(s,lastindex(s))] : s
+    stripdelim(s, d::AbstractString) = endswith(s, d) ? s[1:prevind(s,lastindex(s),length(d))] : s
+    function readuntil(f, d; keep::Bool = false)
+        s = Base.readuntil(f, d)
+        if keep || isempty(s)
+            return s
+        else
+            return stripdelim(s, d)
+        end
+    end
+    readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
 # https://github.com/JuliaLang/julia/pull/18727

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -530,6 +530,39 @@ end
 @test collect(Compat.eachline(IOBuffer("x\ny"), keep=false)) == ["x", "y"]
 @test collect(Compat.eachline(IOBuffer("x\ny"), keep=true))  == ["x\n", "y"]
 
+# PR 25646
+for (t, s, m, kept) in [
+        ("a", "ab", "a", "a"),
+        ("b", "ab", "b", "b"),
+        ("α", "αγ", "α", "α"),
+        ("ab", "abc", "ab", "ab"),
+        ("bc", "abc", "bc", "bc"),
+        ("αβ", "αβγ", "αβ", "αβ"),
+        ("aaabc", "ab", "aa", "aaab"),
+        ("aaabc", "ac", "aaabc", "aaabc"),
+        ("aaabc", "aab", "a", "aaab"),
+        ("aaabc", "aac", "aaabc", "aaabc"),
+        ("αααβγ", "αβ", "αα", "αααβ"),
+        ("αααβγ", "ααβ", "α", "αααβ"),
+        ("αααβγ", "αγ", "αααβγ", "αααβγ"),
+        ("barbarbarians", "barbarian", "bar", "barbarbarian"),
+        ("abcaabcaabcxl", "abcaabcx", "abca", "abcaabcaabcx"),
+        ("abbaabbaabbabbaax", "abbaabbabbaax", "abba", "abbaabbaabbabbaax"),
+        ("abbaabbabbaabbaabbabbaax", "abbaabbabbaax", "abbaabbabba", "abbaabbabbaabbaabbabbaax"),
+       ]
+    local t, s, m, kept
+    @test Compat.readuntil(IOBuffer(t), s) == m
+    @test Compat.readuntil(IOBuffer(t), s, keep=true) == kept
+    @test Compat.readuntil(IOBuffer(t), SubString(s, firstindex(s))) == m
+    @test Compat.readuntil(IOBuffer(t), SubString(s, firstindex(s)), keep=true) == kept
+    @test Compat.readuntil(IOBuffer(t), GenericString(s)) == m
+    @test Compat.readuntil(IOBuffer(t), GenericString(s), keep=true) == kept
+    @test Compat.readuntil(IOBuffer(t), Vector{UInt8}(codeunits(s))) == Vector{UInt8}(codeunits(m))
+    @test Compat.readuntil(IOBuffer(t), Vector{UInt8}(codeunits(s)), keep=true) == Vector{UInt8}(codeunits(kept))
+    @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}) == Vector{Char}(m)
+    @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
+end
+
 # PR 18727
 let
     iset = Set([17, 4711])


### PR DESCRIPTION
This is to allow for the `keep` keyword argument, which was added in https://github.com/JuliaLang/julia/pull/25646 (while also setting it to `false` by default - this was a breaking change).

The code is basically copy-pasted from current Base with a few back-porting changes.
The tests are also taken from the Julia repo, basically as-is.