### PR TITLE
new norm, dot, and opnorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Unicode.isnumeric` is now available as `isnumeric` ([#25479]).
 
+* `vecnorm` and `vecdot` are now `Compat.norm` and `Compat.dot`, respectively, while the
+  old `norm(A::AbstractMatrix, p=2)` is now `Compat.opnorm` ([#27401]).  `import Compat: ⋅`
+  to get `Compat.dot` as the binary operator `⋅`.
+
 * `atan2` is now a 2-argument method of `atan` ([#27253]).
 
 ## New macros
@@ -648,3 +652,4 @@ includes this fix. Find the minimum version from there.
 [#27258]: https://github.com/JuliaLang/julia/issues/27258
 [#27298]: https://github.com/JuliaLang/julia/issues/27298
 [#27253]: https://github.com/JuliaLang/julia/issues/27253
+[#27401]: https://github.com/JuliaLang/julia/issues/27401

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1933,6 +1933,15 @@ if VERSION < v"0.7.0-DEV.5278"
     export something
 end
 
+if !isdefined(LinearAlgebra, :opnorm) # julia#27401
+    opnorm(A::AbstractMatrix, p::Real=2) = LinearAlgebra.norm(A, p)
+    norm(x, p::Real=2) = LinearAlgebra.vecnorm(x, p)
+    dot(x, y) = LinearAlgebra.vecdot(x, y)
+    const ⋅ = dot
+else
+    const opnorm = LinearAlgebra.opnorm
+end
+
 # https://github.com/JuliaLang/julia/pull/27253
 @static if VERSION < v"0.7.0-alpha.44"
     Base.atan(x::Real, y::Real) = atan2(x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1778,6 +1778,14 @@ let sep = Compat.Sys.iswindows() ? ';' : ':'
     end
 end
 
+# julia#27401
+import Compat: ⋅
+@test Compat.opnorm([1 2;3 4]) ≈ 5.464985704219043
+@test Compat.opnorm([1 2;3 4], 1) ≈ 6
+@test Compat.norm([1 2;3 4]) ≈ 5.477225575051661
+@test Compat.norm([1 2;3 4], 1) ≈ 10
+@test Compat.dot([1 2;3 4], [5 6;7 8]) == [1 2;3 4] ⋅ [5 6;7 8] ≈ 70
+
 # 0.7.0-alpha.44
 @test atan(1, 2) == atan(0.5)
 @test atan(1.0, 2.0) == atan(0.5)


### PR DESCRIPTION
Compat for JuliaLang/julia#27401 via `Compat.norm`, `Compat.dot`, and `Compat.opnorm`.