### PR TITLE
Drop `retry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * There are versions of `InexactError`, `DomainError`, and `OverflowError` that take the same arguments as introduced in Julia 0.7-DEV ([#20005], [#22751], [#22761]).
 
-* `retry` for the more flexible `retry` method introduced in 0.6 which includes support for kwargs ([#19331], [#21419]).
-
 * `Base.rtoldefault` how takes a third parameter `atol`.
   The two argument form is deprecated in favor of the three arguments form with `atol=0`.
 
@@ -519,7 +517,6 @@ includes this fix. Find the minimum version from there.
 [#18977]: https://github.com/JuliaLang/julia/issues/18977
 [#19088]: https://github.com/JuliaLang/julia/issues/19088
 [#19246]: https://github.com/JuliaLang/julia/issues/19246
-[#19331]: https://github.com/JuliaLang/julia/issues/19331
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19635]: https://github.com/JuliaLang/julia/issues/19635
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
@@ -537,7 +534,6 @@ includes this fix. Find the minimum version from there.
 [#21197]: https://github.com/JuliaLang/julia/issues/21197
 [#21257]: https://github.com/JuliaLang/julia/issues/21257
 [#21346]: https://github.com/JuliaLang/julia/issues/21346
-[#21419]: https://github.com/JuliaLang/julia/issues/21419
 [#21709]: https://github.com/JuliaLang/julia/issues/21709
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
 [#22182]: https://github.com/JuliaLang/julia/issues/22182
@@ -574,11 +570,9 @@ includes this fix. Find the minimum version from there.
 [#24490]: https://github.com/JuliaLang/julia/issues/24490
 [#24605]: https://github.com/JuliaLang/julia/issues/24605
 [#24647]: https://github.com/JuliaLang/julia/issues/24647
-[#24648]: https://github.com/JuliaLang/julia/issues/24648
 [#24652]: https://github.com/JuliaLang/julia/issues/24652
 [#24657]: https://github.com/JuliaLang/julia/issues/24657
 [#24673]: https://github.com/JuliaLang/julia/issues/24673
-[#24714]: https://github.com/JuliaLang/julia/issues/24714
 [#24785]: https://github.com/JuliaLang/julia/issues/24785
 [#24808]: https://github.com/JuliaLang/julia/issues/24808
 [#24831]: https://github.com/JuliaLang/julia/issues/24831
@@ -647,6 +641,6 @@ includes this fix. Find the minimum version from there.
 [#26670]: https://github.com/JuliaLang/julia/issues/26670
 [#26850]: https://github.com/JuliaLang/julia/issues/26850
 [#27077]: https://github.com/JuliaLang/julia/issues/27077
+[#27253]: https://github.com/JuliaLang/julia/issues/27253
 [#27258]: https://github.com/JuliaLang/julia/issues/27258
 [#27298]: https://github.com/JuliaLang/julia/issues/27298
-[#27253]: https://github.com/JuliaLang/julia/issues/27253

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -91,64 +91,6 @@ end
         eval(mod, :(include_string($code, $fname)))
 end
 
-if VERSION < v"0.6.0-dev.2042"
-    include_string(@__MODULE__, """
-        immutable ExponentialBackOff
-            n::Int
-            first_delay::Float64
-            max_delay::Float64
-            factor::Float64
-            jitter::Float64
-
-            function ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
-                all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || error("all inputs must be non-negative")
-                new(n, first_delay, max_delay, factor, jitter)
-            end
-        end
-    """)
-
-    """
-        ExponentialBackOff(; n=1, first_delay=0.05, max_delay=10.0, factor=5.0, jitter=0.1)
-
-    A [`Float64`](@ref) iterator of length `n` whose elements exponentially increase at a
-    rate in the interval `factor` * (1 ± `jitter`).  The first element is
-    `first_delay` and all elements are clamped to `max_delay`.
-    """
-    ExponentialBackOff(; n=1, first_delay=0.05, max_delay=10.0, factor=5.0, jitter=0.1) =
-        ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
-    Base.start(ebo::ExponentialBackOff) = (ebo.n, min(ebo.first_delay, ebo.max_delay))
-    function Base.next(ebo::ExponentialBackOff, state)
-        next_n = state[1]-1
-        curr_delay = state[2]
-        next_delay = min(ebo.max_delay, state[2] * ebo.factor * (1.0 - ebo.jitter + (rand() * 2.0 * ebo.jitter)))
-        (curr_delay, (next_n, next_delay))
-    end
-    Base.done(ebo::ExponentialBackOff, state) = state[1]<1
-    Base.length(ebo::ExponentialBackOff) = ebo.n
-
-    function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)
-        (args...; kwargs...) -> begin
-            state = start(delays)
-            while true
-                try
-                    return f(args...; kwargs...)
-                catch e
-                    done(delays, state) && rethrow(e)
-                    if check !== nothing
-                        state, retry_or_not = check(state, e)
-                        retry_or_not || rethrow(e)
-                    end
-                end
-                (delay, state) = next(delays, state)
-                sleep(delay)
-            end
-        end
-    end
-else
-    import Base.ExponentialBackOff
-    import Base.retry
-end
-
 import Base: redirect_stdin, redirect_stdout, redirect_stderr
 if VERSION < v"0.6.0-dev.374"
     for (F,S) in ((:redirect_stdin, :STDIN), (:redirect_stdout, :STDOUT), (:redirect_stderr, :STDERR))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,53 +111,6 @@ cd(dirwalk) do
 end
 rm(dirwalk, recursive=true)
 
-let
-    # Subset of tests copied from base test/error.jl
-    function foo_error(c, n)
-        c[1] += 1
-        if c[1] <= n
-            error("foo")
-        end
-        return 7
-    end
-
-    # Success on first attempt
-    c = [0]
-    @test Compat.retry(foo_error)(c, 0) == 7
-    @test c[1] == 1
-
-    # Success on second attempt
-    c = [0]
-    @test Compat.retry(foo_error)(c,1) == 7
-    @test c[1] == 2
-
-    # 2 failed retry attempts, so exception is raised
-    c = [0]
-    ex = try
-        Compat.retry(foo_error, delays=Compat.ExponentialBackOff(n=2))(c, 3)
-    catch e
-        e
-    end
-
-    c = [0]
-    ex = try
-        Compat.retry(
-            foo_error,
-            check=(s,e)->(s, try e.http_status_code == "503" end != true)
-        )(c, 2)
-    catch e
-        e
-    end
-    @test typeof(ex) == ErrorException
-    @test ex.msg == "foo"
-    @test c[1] == 2
-
-    # Functions with keyword arguments
-    foo_kwargs(x; y=5) = x + y
-    @test Compat.retry(foo_kwargs)(3) == 8
-    @test Compat.retry(foo_kwargs)(3; y=4) == 7
-end
-
 for os in [:apple, :bsd, :linux, :unix, :windows]
     from_base = if VERSION >= v"0.7.0-DEV.914"
         Expr(:., Expr(:., :Base, Base.Meta.quot(:Sys)), Base.Meta.quot(Symbol("is", os)))


### PR DESCRIPTION
This is not needed anymore on Julia 0.6 or later and the test threw a deprecation warning.