### PR TITLE
required keyword arguments working

### DIFF
--- a/src/compatmacro.jl
+++ b/src/compatmacro.jl
@@ -25,12 +25,25 @@ else
     new_style_typealias(ex) = false
 end
 
+"Provides the error message if no required keyword argument is given."
+rka_error_message(sym) = string("RequiredKeywordArgumentError: `", sym, "` is a required keyword argument, please provide `", sym, " = ...`.")
+
+"Convert a functions symbol argument to the corresponding required keyword argument."
+function symbol2kw(sym::Symbol)
+    Expr(:kw, sym, Expr(:call, error, rka_error_message(sym)))
+end
+symbol2kw(arg) = arg
+
 function _compat(ex::Expr)
     if ex.head === :call
         f = ex.args[1]
         if VERSION < v"0.6.0-dev.826" && length(ex.args) == 3 && # julia#18510
                 istopsymbol(withincurly(ex.args[1]), :Base, :Nullable)
             ex = Expr(:call, f, ex.args[2], Expr(:call, :(Compat._Nullable_field2), ex.args[3]))
+        end
+        if length(ex.args) > 1 && isexpr(ex.args[2], :parameters)
+            params = ex.args[2]
+            params.args = map(symbol2kw, params.args)
         end
     elseif ex.head === :curly
         f = ex.args[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1856,4 +1856,35 @@ let
     @test Compat.split(str, r"\.+:\.+"; limit=3, keepempty=true) == ["a","ba","cba.:.:.dcba.:."]
 end
 
+# test required keyword arguments
+@compat func1() = 1
+@test func1() == 1 # using the function works
+@compat func2(x) = x
+@test func2(3) == 3 # using the function works
+@compat func3(;y) = y
+@test func3(y=2) == 2 # using the function works
+try
+    func3()
+catch e
+    @test isa(e, ErrorException)
+    @test e.msg == Compat.rka_error_message(:y)
+end
+@compat func4(x; z) = x*z
+@test func4(2,z=3) == 6 # using the function works
+try
+    func4(2)
+catch e
+    @test isa(e, ErrorException)
+    @test e.msg == Compat.rka_error_message(:z)
+end
+@compat func5(;x=1, y) = x*y
+@test func5(y=3) == 3
+@test func5(y=3, x=2) == 6
+try
+    func5(x=2)
+catch e
+    @test isa(e, ErrorException)
+    @test e.msg == Compat.rka_error_message(:y)
+end
+
 nothing


### PR DESCRIPTION
Following up on the comment by @Keno in this PR JuliaLang/METADATA.jl#15489 I added the functionality to understand required keyword arguments to `@compat`. Basically that means
```Julia
@compat f(;x) = [...]
```
is equivalent to 
```Julia
f(;x=error("RequiredKeywordArgumentError: `x` is a required keyword argument, please provide `x = ...`.")) = [...]
```

As this is my first submission to a JuliaLang rep, could you check that the style etc. matches what you would  expect?