### PR TITLE
(map)reduce with init keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Currently, the `@compat` macro supports the following syntaxes:
   `Compat.median`, `Compat.minimum`, `Compat.prod`, `Compat.reduce`, `Compat.sort`,
   and `Compat.sum`  with `dims` keyword argument ([#25989],[#26369]).
 
+* `Compat.mapreduce` and `Compat.reduce` with `init` keyword argument ([#27711]).
+
 * `selectdim` to obtain a view of an array with a specified index for a specified dimension ([#26009]).
 
 * `squeeze` with `dims` as keyword argument ([#26660]).
@@ -660,4 +662,6 @@ includes this fix. Find the minimum version from there.
 [#27258]: https://github.com/JuliaLang/julia/issues/27258
 [#27298]: https://github.com/JuliaLang/julia/issues/27298
 [#27401]: https://github.com/JuliaLang/julia/issues/27401
+[#27711]: https://github.com/JuliaLang/julia/issues/27711
 [#27828]: https://github.com/JuliaLang/julia/issues/27828
+[#27834]: https://github.com/JuliaLang/julia/issues/27834

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1780,16 +1780,19 @@ if VERSION < v"0.7.0-DEV.4064"
     cor(a::AbstractMatrix; dims=nothing) = dims===nothing ? Base.cor(a) : Base.cor(a, dims)
     cor(a::AbstractVecOrMat, b::AbstractVecOrMat; dims=nothing) =
         dims===nothing ? Base.cor(a, b) : Base.cor(a, b, dims)
-    mapreduce(f, op, a::AbstractArray; dims=nothing) =
-        dims===nothing ? Base.mapreduce(f, op, a) : Base.mapreducedim(f, op, a, dims)
-    mapreduce(f, op, v0, a::AbstractArray; dims=nothing) =
-        dims===nothing ? Base.mapreduce(f, op, v0, a) : Base.mapreducedim(f, op, a, dims, v0)
-    reduce(op, a::AbstractArray; dims=nothing) =
-        dims===nothing ? Base.reduce(op, a) : Base.reducedim(op, a, dims)
-    reduce(op, v0, a::AbstractArray; dims=nothing) =
-        dims===nothing ? Base.reduce(op, v0, a) : Base.reducedim(op, a, dims, v0)
+    mapreduce(f, op, a::AbstractArray; dims=nothing, init=nothing) =
+        init === nothing ? (dims===nothing ? Base.mapreduce(f, op, a) : Base.mapreducedim(f, op, a, dims)) :
+                           (dims===nothing ? Base.mapreduce(f, op, init, a) : Base.mapreducedim(f, op, a, dims, init))
+    reduce(op, a::AbstractArray; dims=nothing, init=nothing) =
+        init === nothing ? (dims===nothing ? Base.reduce(op, a) : Base.reducedim(op, a, dims)) :
+                           (dims===nothing ? Base.reduce(op, init, a) : Base.reducedim(op, a, dims, init))
     accumulate!(op, out, a; dims=nothing) =
         dims===nothing ? Base.accumulate!(op, out, a) : Base.accumulate!(op, out, a, dims)
+elseif VERSION < v"0.7.0-beta.81" # julia#27711
+    mapreduce(f, op, a::AbstractArray; dims=nothing, init=nothing) =
+        init === nothing ? Base.mapreduce(f, op, a; dims=dims) : Base.mapreduce(f, op, init, a; dims=dims)
+    reduce(op, a::AbstractArray; dims=nothing, init=nothing) =
+        init === nothing ? Base.reduce(op, a; dims=dims) : Base.reduce(op, init, a; dims=dims)
 end
 if VERSION < v"0.7.0-DEV.4534"
     reverse(a::AbstractArray; dims=nothing) =

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1788,6 +1788,11 @@ if VERSION < v"0.7.0-DEV.4064"
                            (dims===nothing ? Base.reduce(op, init, a) : Base.reducedim(op, a, dims, init))
     accumulate!(op, out, a; dims=nothing) =
         dims===nothing ? Base.accumulate!(op, out, a) : Base.accumulate!(op, out, a, dims)
+    # kept for compatibility with early adopters
+    mapreduce(f, op, v0, a::AbstractArray; dims=nothing) =
+        mapreduce(f, op, a, dims=dims, init=v0)
+    reduce(op, v0, a::AbstractArray; dims=nothing) =
+        reduce(op, a, dims=dims, init=v0)
 elseif VERSION < v"0.7.0-beta.81" # julia#27711
     mapreduce(f, op, a::AbstractArray; dims=nothing, init=nothing) =
         init === nothing ? Base.mapreduce(f, op, a; dims=dims) : Base.mapreduce(f, op, init, a; dims=dims)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1795,9 +1795,11 @@ if VERSION < v"0.7.0-DEV.4064"
         reduce(op, a, dims=dims, init=v0)
 elseif VERSION < v"0.7.0-beta.81" # julia#27711
     mapreduce(f, op, a::AbstractArray; dims=nothing, init=nothing) =
-        init === nothing ? Base.mapreduce(f, op, a; dims=dims) : Base.mapreduce(f, op, init, a; dims=dims)
+        init === nothing ? (dims===nothing ? Base.mapreduce(f, op, a) : Base.mapreduce(f, op, a, dims=dims)) :
+                           (dims===nothing ? Base.mapreduce(f, op, init, a) : Base.mapreduce(f, op, init, a, dims=dims))
     reduce(op, a::AbstractArray; dims=nothing, init=nothing) =
-        init === nothing ? Base.reduce(op, a; dims=dims) : Base.reduce(op, init, a; dims=dims)
+        init === nothing ? (dims===nothing ? Base.reduce(op, a) : Base.reduce(op, a, dims=dims)) :
+                           (dims===nothing ? Base.reduce(op, init, a) : Base.reduce(op, init, a, dims=dims))
 end
 if VERSION < v"0.7.0-DEV.4534"
     reverse(a::AbstractArray; dims=nothing) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1596,15 +1596,15 @@ end
 @test Compat.mapreduce(string, *, [1 2; 3 4]) == "1324"
 Issue26488 && @test Compat.mapreduce(string, *, [1 2; 3 4], dims=1) == ["13" "24"]
 Issue26488 && @test Compat.mapreduce(string, *, [1 2; 3 4], dims=2) == hcat(["12", "34"])
-@test Compat.mapreduce(string, *, "z", [1 2; 3 4]) == "z1324"
-@test Compat.mapreduce(string, *, "z", [1 2; 3 4], dims=1) == ["z13" "z24"]
-@test Compat.mapreduce(string, *, "z", [1 2; 3 4], dims=2) == hcat(["z12", "z34"])
+@test Compat.mapreduce(string, *, [1 2; 3 4], init="z") == "z1324"
+@test Compat.mapreduce(string, *, [1 2; 3 4], dims=1, init="z") == ["z13" "z24"]
+@test Compat.mapreduce(string, *, [1 2; 3 4], dims=2, init="z") == hcat(["z12", "z34"])
 @test Compat.reduce(*, [1 2; 3 4]) == 24
 @test Compat.reduce(*, [1 2; 3 4], dims=1) == [3 8]
 @test Compat.reduce(*, [1 2; 3 4], dims=2) == hcat([2, 12])
-@test Compat.reduce(*, 10, [1 2; 3 4]) == 240
-@test Compat.reduce(*, 10, [1 2; 3 4], dims=1) == [30 80]
-@test Compat.reduce(*, 10, [1 2; 3 4], dims=2) == hcat([20, 120])
+@test Compat.reduce(*, [1 2; 3 4], init=10) == 240
+@test Compat.reduce(*, [1 2; 3 4], dims=1, init=10) == [30 80]
+@test Compat.reduce(*, [1 2; 3 4], dims=2, init=10) == hcat([20, 120])
 @test Compat.sort([1, 2, 3, 4]) == [1, 2, 3, 4]
 @test Compat.sort([1 2; 3 4], dims=1) == [1 2; 3 4]
 @test Compat.sort([1 2; 3 4], dims=2) == [1 2; 3 4]


### PR DESCRIPTION
Cherry-picked from #583 by @stevengj so we can have it before the Statistics issue is settled. Also re-added the legacy methods taking `v0` as positional argument, but `dims` as keyword argument, to avoid breaking any packages on Julia 0.6 that have already adopted that.