### PR TITLE
Add Sockets.DNSError

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -6,7 +6,7 @@ module Compat
 if VERSION < v"0.7.0-DEV.4442"
     @eval module Sockets
         import Base:
-            @ip_str, IPAddr, IPv4, IPv6, UDPSocket, TCPSocket,
+            @ip_str, IPAddr, IPv4, IPv6, UDPSocket, TCPSocket, DNSError,
             accept, connect, getaddrinfo, getipaddr, getsockname, listen,
             listenany, recv, recvfrom, send, bind
 


### PR DESCRIPTION
It's available in the Sockets stdlib module (and as `Base.DNSError` in earlier Julia version) but is not exported. This adds it to the imports when defining Compat.Sockets but does not export it.