### PR TITLE
Add compatibility for cat with dims kw argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `squeeze` with `dims` as keyword argument ([#26660]).
 
+* `cat` with `dims` as keyword argument ([#27163])
+
 * Single-argument `permutedims(x)` for matrices and vectors ([#24839]).
 
 * `fetch` for `Task`s ([#25940]).
@@ -661,6 +663,7 @@ includes this fix. Find the minimum version from there.
 [#26670]: https://github.com/JuliaLang/julia/issues/26670
 [#26850]: https://github.com/JuliaLang/julia/issues/26850
 [#27077]: https://github.com/JuliaLang/julia/issues/27077
+[#27163]: https://github.com/JuliaLang/julia/issues/27163
 [#27253]: https://github.com/JuliaLang/julia/issues/27253
 [#27258]: https://github.com/JuliaLang/julia/issues/27258
 [#27298]: https://github.com/JuliaLang/julia/issues/27298

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `squeeze` with `dims` as keyword argument ([#26660]).
 
-* `cat` with `dims` as keyword argument ([#27163])
+* `Compat.cat` with `dims` as keyword argument ([#27163])
 
 * Single-argument `permutedims(x)` for matrices and vectors ([#24839]).
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1830,6 +1830,9 @@ end
 if VERSION < v"0.7.0-DEV.4738"
     Base.squeeze(A; dims=error("squeeze: keyword argument dims not assigned")) = squeeze(A, dims)
 end
+if VERSION < v"0.7.0-DEV.5165" # julia#27163
+    cat(X...; dims = throw(UndefKeywordError("cat: keyword argument dims not assigned"))) = Base.cat(dims, X...)
+end
 
 if !isdefined(Base, :selectdim) # 0.7.0-DEV.3976
     export selectdim

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1652,6 +1652,13 @@ if VERSION < v"0.7.0-beta2.143"
     @test_throws Exception squeeze([1,2])
 end
 
+# 0.7.0-DEV.5165
+@test Compat.cat([1, 2], [3, 4, 5], dims = 1) == [1, 2, 3, 4, 5]
+@test Compat.cat([1, 2], [3, 4], dims = 2) == [1 3; 2 4]
+if VERSION < v"0.7.0-DEV.5165"
+    @test_throws UndefKeywordError Compat.cat([1, 2], [3, 4])
+end
+
 # 0.7.0-DEV.3976
 let A = rand(5,5)
     @test selectdim(A, 1, 3) == A[3, :]


### PR DESCRIPTION
cat(dims, Xs...) was deprecated to cat(Xs..., dims=dim) in [#27163], but as
described in #612 support for the new signature is missing in Compat.

Fixes #612

[#27163]: https://github.com/JuliaLang/julia/issue/27163