### PR TITLE
squeeze is now dropdims

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `realmin` and `realmax` are now `floatmin` and `floatmax` ([#28302])
 
+* `squeeze` is now `dropdims` ([#28303]).
+
 ## New macros
 
 * `@__DIR__` has been added ([#18380])
@@ -671,3 +673,4 @@ includes this fix. Find the minimum version from there.
 [#27828]: https://github.com/JuliaLang/julia/issues/27828
 [#27834]: https://github.com/JuliaLang/julia/issues/27834
 [#28302]: https://github.com/JuliaLang/julia/issues/28302
+[#28303]: https://github.com/JuliaLang/julia/issues/28303

--- a/README.md
+++ b/README.md
@@ -292,8 +292,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `selectdim` to obtain a view of an array with a specified index for a specified dimension ([#26009]).
 
-* `squeeze` with `dims` as keyword argument ([#26660]).
-
 * Single-argument `permutedims(x)` for matrices and vectors ([#24839]).
 
 * `fetch` for `Task`s ([#25940]).
@@ -434,7 +432,7 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `realmin` and `realmax` are now `floatmin` and `floatmax` ([#28302])
 
-* `squeeze` is now `dropdims` ([#28303]).
+* `squeeze` is now `dropdims` ([#28303], [#26660]).
 
 ## New macros
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -2011,6 +2011,11 @@ if VERSION < v"0.7.0-beta2.169"
     export floatmin, floatmax
 end
 
+# https://github.com/JuliaLang/julia/pull/28303
+if VERSION < v"0.7.0-beta2.143"
+    dropdims(X; dims = throw(UndefKeywordError("dropdims: keyword argument dims not assigned"))) = squeeze(X, dims)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -2013,6 +2013,7 @@ end
 
 # https://github.com/JuliaLang/julia/pull/28303
 if VERSION < v"0.7.0-beta2.143"
+    export dropdims
     # https://github.com/JuliaLang/julia/pull/26660
     if VERSION >= v"0.7.0-DEV.4738"
         dropdims(

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -2013,7 +2013,20 @@ end
 
 # https://github.com/JuliaLang/julia/pull/28303
 if VERSION < v"0.7.0-beta2.143"
-    dropdims(X; dims = throw(UndefKeywordError("dropdims: keyword argument dims not assigned"))) = squeeze(X, dims)
+    # https://github.com/JuliaLang/julia/pull/26660
+    if VERSION >= v"0.7.0-DEV.4738"
+        dropdims(
+            X;
+            dims = throw(
+                UndefKeywordError("dropdims: keyword argument dims not assigned"))
+        ) = squeeze(X, dims = dims)
+    else
+        dropdims(
+            X;
+            dims = throw(
+                UndefKeywordError("dropdims: keyword argument dims not assigned"))
+        ) = squeeze(X, dims)
+    end
 end
 
 include("deprecated.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1935,4 +1935,12 @@ end
 @test floatmax(Float32) == @eval $(Core.Intrinsics.bitcast(Float32, 0x7f7fffff))
 @test floatmin(zero(Float64)) == floatmin(Float64)
 
+# 0.7.0-beta2.143
+if VERSION < v"0.7.0-beta2.143"
+    let a = reshape(Vector(1:4),(2,2,1,1)), b = reshape(Vector(1:4), (2,2,1))
+        @test Compat.dropdims(a; dims=3) == b
+        @test_throws UndefKeywordError Compat.dropdims(a)
+    end
+end
+
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1938,8 +1938,8 @@ end
 # 0.7.0-beta2.143
 if VERSION < v"0.7.0-beta2.143"
     let a = reshape(Vector(1:4),(2,2,1,1)), b = reshape(Vector(1:4), (2,2,1))
-        @test Compat.dropdims(a; dims=3) == b
-        @test_throws UndefKeywordError Compat.dropdims(a)
+        @test dropdims(a; dims=3) == b
+        @test_throws UndefKeywordError dropdims(a)
     end
 end
 


### PR DESCRIPTION
`squeeze` was renamed `dropdims` in [#28303](https://github.com/JuliaLang/julia/pull/28303)

Fixes #617