### PR TITLE
Add Tuple method for argmin/argmax

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1400,9 +1400,11 @@ end
         argmin(x::AbstractArray) = CartesianIndex(ind2sub(x, indmin(x)))
         argmin(x::AbstractVector) = indmin(x)
         argmin(x::Associative) = first(Iterators.drop(keys(x), indmin(values(x))-1))
+        argmin(x::Tuple) = indmin(x)
         argmax(x::AbstractArray) = CartesianIndex(ind2sub(x, indmax(x)))
         argmax(x::AbstractVector) = indmax(x)
         argmax(x::Associative) = first(Iterators.drop(keys(x), indmax(values(x))-1))
+        argmax(x::Tuple) = indmax(x)
     end
     export argmin, argmax
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1231,9 +1231,11 @@ end
 @test argmax([10,12,9,11]) == 2
 @test argmax([10 12; 9 11]) == CartesianIndex(1, 2)
 @test argmax(Dict(:z=>10, :y=>12, :x=>9, :w=>11)) == :y
+@test argmax((-5, 6, 10)) == 3
 @test argmin([10,12,9,11]) == 3
 @test argmin([10 12; 9 11]) == CartesianIndex(2, 1)
 @test argmin(Dict(:z=>10, :y=>12, :x=>9, :w=>11)) == :x
+@test argmin((1.0, -3, 0.f0)) == 2
 
 # 0.7.0-DEV.3415
 @test findall(x -> x==1, [1, 2, 3, 2, 1]) == [1, 5]


### PR DESCRIPTION
Currently, only a limited set of input collections are supported
with argmin/argmax.  Add a fallback to indmin/indmax for remaining
types, which allows them to work on Tuples.

Fixes #621.