### PR TITLE
Remove more pre-0.6-only stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `unsafe_trunc(::Type{<:Integer}, ::Integer)` is supported on 0.5. ([#18629])
-
 * `bswap` is supported for `Complex` arguments on 0.5 and below. ([#21346])
 
 * `Compat.invokelatest` is equivalent to `Base.invokelatest` in Julia 0.6,
@@ -460,7 +458,6 @@ includes this fix. Find the minimum version from there.
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
-[#18629]: https://github.com/JuliaLang/julia/issues/18629
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
 [#20005]: https://github.com/JuliaLang/julia/issues/20005

--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Compat.invokelatest` supports keywords ([#22646]).
 
-* `Compat.StringVector` is supported on 0.5 and below. On 0.6 and later, it aliases `Base.StringVector`. This function allocates a `Vector{UInt8}` whose data can be made into a `String` in constant time; that is, without copying. On 0.5 and later, use `String(...)` with the vector allocated by `StringVector` as an argument to create a string without copying. Note that if 0.4 support is needed, `Compat.UTF8String(...)` should be used instead. ([#19449])
-
 * `@__MODULE__` is aliased to `current_module()` for Julia versions 0.6 and below. Versions of `Base.binding_module`, `expand`, `macroexpand`, and `include_string` were added that accept a module as the first argument. ([#22064])
 
 * `Cmd` elements can be accessed as if the `Cmd` were an array of strings for 0.6 and below ([#21197]).
@@ -456,7 +454,6 @@ includes this fix. Find the minimum version from there.
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
-[#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974

--- a/README.md
+++ b/README.md
@@ -133,10 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `Compat.invokelatest` is equivalent to `Base.invokelatest` in Julia 0.6,
-  but works in Julia 0.5+, and allows you to guarantee that a function call
-  invokes the latest version of a function ([#19784]).
-
 * `Compat.invokelatest` supports keywords ([#22646]).
 
 * `@__MODULE__` is aliased to `current_module()` for Julia versions 0.6 and below. Versions of `Base.binding_module`, `expand`, `macroexpand`, and `include_string` were added that accept a module as the first argument. ([#22064])
@@ -454,7 +450,6 @@ includes this fix. Find the minimum version from there.
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
-[#19784]: https://github.com/JuliaLang/julia/issues/19784
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21197]: https://github.com/JuliaLang/julia/issues/21197

--- a/README.md
+++ b/README.md
@@ -120,11 +120,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## New functions, macros, and methods
 
-* [`normalize`](http://docs.julialang.org/en/latest/stdlib/linalg/?highlight=normalize#Base.normalize) and [`normalize!`](http://docs.julialang.org/en/latest/stdlib/linalg/?highlight=normalize#Base.normalize!), normalizes a vector with respect to the p-norm ([#13681])
-
-* `transcode` converts between UTF-xx string encodings in Julia 0.5 (as a lightweight
-   alternative to the LegacyStrings package) ([#17323])
-
 * `Compat.readline` with `keep` keyword argument ([#25646])
 
 * `Compat.eachline` with `keep` keyword argument ([#25646])
@@ -447,9 +442,7 @@ includes this fix. Find the minimum version from there.
 * Now specify the correct minimum version for Compat in your REQUIRE file by
 `Compat <version>`
 
-[#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
-[#17323]: https://github.com/JuliaLang/julia/issues/17323
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21197]: https://github.com/JuliaLang/julia/issues/21197

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `isassigned(::RefValue)` is supported on 0.5 and below. ([#18082])
-
 * `unsafe_trunc(::Type{<:Integer}, ::Integer)` is supported on 0.5. ([#18629])
 
 * `bswap` is supported for `Complex` arguments on 0.5 and below. ([#21346])
@@ -462,7 +460,6 @@ includes this fix. Find the minimum version from there.
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
 [#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
-[#18082]: https://github.com/JuliaLang/julia/issues/18082
 [#18629]: https://github.com/JuliaLang/julia/issues/18629
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19784]: https://github.com/JuliaLang/julia/issues/19784

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `convert` can convert between different `Set` types on 0.5 and below. ([#18727])
-
 * `isassigned(::RefValue)` is supported on 0.5 and below. ([#18082])
 
 * `unsafe_trunc(::Type{<:Integer}, ::Integer)` is supported on 0.5. ([#18629])
@@ -466,7 +464,6 @@ includes this fix. Find the minimum version from there.
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
 [#18082]: https://github.com/JuliaLang/julia/issues/18082
 [#18629]: https://github.com/JuliaLang/julia/issues/18629
-[#18727]: https://github.com/JuliaLang/julia/issues/18727
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
 [#20005]: https://github.com/JuliaLang/julia/issues/20005

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `zeros` and `ones` support an interface the same as `similar` ([#19635])
-
 * `convert` can convert between different `Set` types on 0.5 and below. ([#18727])
 
 * `isassigned(::RefValue)` is supported on 0.5 and below. ([#18082])
@@ -470,7 +468,6 @@ includes this fix. Find the minimum version from there.
 [#18629]: https://github.com/JuliaLang/julia/issues/18629
 [#18727]: https://github.com/JuliaLang/julia/issues/18727
 [#19449]: https://github.com/JuliaLang/julia/issues/19449
-[#19635]: https://github.com/JuliaLang/julia/issues/19635
 [#19784]: https://github.com/JuliaLang/julia/issues/19784
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * The `isabstract`, `parameter_upper_bound`, `typename` reflection methods were added in Julia 0.6. This package re-exports these from the `Compat.TypeUtils` submodule. On earlier versions of julia, that module contains the same functions, but operating on the pre-0.6 type system representation.
 
-* `bswap` is supported for `Complex` arguments on 0.5 and below. ([#21346])
-
 * `Compat.invokelatest` is equivalent to `Base.invokelatest` in Julia 0.6,
   but works in Julia 0.5+, and allows you to guarantee that a function call
   invokes the latest version of a function ([#19784]).
@@ -463,7 +461,6 @@ includes this fix. Find the minimum version from there.
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21197]: https://github.com/JuliaLang/julia/issues/21197
-[#21346]: https://github.com/JuliaLang/julia/issues/21346
 [#21709]: https://github.com/JuliaLang/julia/issues/21709
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
 [#22182]: https://github.com/JuliaLang/julia/issues/22182

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -180,11 +180,6 @@ import Base.Iterators # TODO deprecate, remove
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-# https://github.com/JuliaLang/julia/pull/18082
-if VERSION < v"0.6.0-dev.2347"
-    Base.isassigned(x::Base.RefValue) = isdefined(x, :x)
-end
-
 @static if VERSION < v"0.6.0-dev.735"
     Base.unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
 end

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -180,11 +180,6 @@ import Base.Iterators # TODO deprecate, remove
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-# https://github.com/JuliaLang/julia/pull/21346
-if VERSION < v"0.6.0-pre.beta.102"
-    Base.bswap(z::Complex) = Complex(bswap(real(z)), bswap(imag(z)))
-end
-
 # https://github.com/JuliaLang/julia/pull/19449
 @static if VERSION < v"0.6.0-dev.1988"
     StringVector(n::Integer) = Vector{UInt8}(n)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -180,12 +180,8 @@ import Base.Iterators # TODO deprecate, remove
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-# https://github.com/JuliaLang/julia/pull/19449
-@static if VERSION < v"0.6.0-dev.1988"
-    StringVector(n::Integer) = Vector{UInt8}(n)
-else
-    using Base: StringVector
-end
+# TODO deprecate/remove this unexported binding (along wiht its tests)
+using Base: StringVector
 
 # https://github.com/JuliaLang/julia/pull/19784
 @static if isdefined(Base, :invokelatest)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -160,17 +160,6 @@ include("arraymacros.jl")
 # julia #18839
 import Base.Iterators # TODO deprecate, remove
 
-if VERSION < v"0.6.0-dev.1653"
-    for (fname, felt) in ((:zeros,:zero), (:ones,:one))
-        @eval begin
-            # allow signature of similar
-            Base.$fname(a::AbstractArray, T::Type, dims::Tuple) = fill!(similar(a, T, dims), $felt(T))
-            Base.$fname(a::AbstractArray, T::Type, dims...) = fill!(similar(a,T,dims...), $felt(T))
-            Base.$fname(a::AbstractArray, T::Type=eltype(a)) = fill!(similar(a,T), $felt(T))
-        end
-    end
-end
-
 # https://github.com/JuliaLang/julia/pull/25646
 @static if VERSION < v"0.7.0-DEV.3510"
     # not exported

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -180,10 +180,6 @@ import Base.Iterators # TODO deprecate, remove
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-@static if VERSION < v"0.6.0-dev.735"
-    Base.unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
-end
-
 # https://github.com/JuliaLang/julia/pull/21346
 if VERSION < v"0.6.0-pre.beta.102"
     Base.bswap(z::Complex) = Complex(bswap(real(z)), bswap(imag(z)))

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -180,12 +180,6 @@ import Base.Iterators # TODO deprecate, remove
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-# https://github.com/JuliaLang/julia/pull/18727
-@static if VERSION < v"0.6.0-dev.838"
-    Base.convert{T}(::Type{Set{T}}, s::Set{T}) = s
-    Base.convert{T}(::Type{Set{T}}, s::Set) = Set{T}(s)
-end
-
 # https://github.com/JuliaLang/julia/pull/18082
 if VERSION < v"0.6.0-dev.2347"
     Base.isassigned(x::Base.RefValue) = isdefined(x, :x)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -183,22 +183,14 @@ end
 # TODO deprecate/remove this unexported binding (along wiht its tests)
 using Base: StringVector
 
-# https://github.com/JuliaLang/julia/pull/19784
-@static if isdefined(Base, :invokelatest)
-    # https://github.com/JuliaLang/julia/pull/22646
-    if VERSION < v"0.7.0-DEV.1139"
-        function invokelatest(f, args...; kwargs...)
-            inner() = f(args...; kwargs...)
-            Base.invokelatest(inner)
-        end
-    else
-        import Base.invokelatest
+# https://github.com/JuliaLang/julia/pull/22646
+if VERSION < v"0.7.0-DEV.1139"
+    function invokelatest(f, args...; kwargs...)
+        inner() = f(args...; kwargs...)
+        Base.invokelatest(inner)
     end
 else
-    function invokelatest(f, args...; kwargs...)
-        kw = [Expr(:kw, k, QuoteNode(v)) for (k, v) in kwargs]
-        eval(current_module(), Expr(:call, f, map(QuoteNode, args)..., kw...))
-    end
+    import Base.invokelatest
 end
 
 # https://github.com/JuliaLang/julia/pull/21197

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,16 +162,6 @@ for (t, s, m, kept) in [
     @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 end
 
-# PR 21346
-let zbuf = IOBuffer([0xbf, 0xc0, 0x00, 0x00, 0x40, 0x20, 0x00, 0x00,
-                     0x40, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                     0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-    z1 = read(zbuf, ComplexF32)
-    z2 = read(zbuf, ComplexF64)
-    @test bswap(z1) === -1.5f0 + 2.5f0im
-    @test bswap(z2) ===  3.5 - 4.5im
-end
-
 # PR 19449
 using Compat: StringVector
 @test length(StringVector(5)) == 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,9 +163,15 @@ for (t, s, m, kept) in [
 end
 
 # PR 19449
+# TODO remove these tests when Compat.StringVector is deprecated
 using Compat: StringVector
 @test length(StringVector(5)) == 5
 @test String(fill!(StringVector(5), 0x61)) == "aaaaa"
+let x = fill!(StringVector(5), 0x61)
+    # 0.7
+    @test pointer(x) == pointer(String(x))
+end
+
 
 # PR 22064
 module Test22064
@@ -246,11 +252,6 @@ eval(Expr(struct_sym, false, :TestType, Expr(:block, :(a::Int), :b)))
 
 # PR 22761
 @test_throws OverflowError throw(OverflowError("overflow"))
-
-let x = fill!(StringVector(5), 0x61)
-    # 0.7
-    @test pointer(x) == pointer(String(x))
-end
 
 # PR 22907
 using Compat: pairs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,10 +162,6 @@ for (t, s, m, kept) in [
     @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 end
 
-# PR 18082
-@test !isassigned(Ref{String}())
-@test isassigned(Ref{String}("Test"))
-
 @test unsafe_trunc(Int8, 128) === Int8(-128)
 @test_throws InexactError trunc(Int8, 128)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,9 +162,6 @@ for (t, s, m, kept) in [
     @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 end
 
-@test unsafe_trunc(Int8, 128) === Int8(-128)
-@test_throws InexactError trunc(Int8, 128)
-
 # PR 21346
 let zbuf = IOBuffer([0xbf, 0xc0, 0x00, 0x00, 0x40, 0x20, 0x00, 0x00,
                      0x40, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,19 +121,6 @@ let x = [1,2,3]
     @test f(x) == [1,4,9]
 end
 
-if VERSION < v"0.6.0-dev.1653"
-    for (A,val) in ((zeros(1:5, Float32, 3, 2), 0),
-                    (ones(1:5, Float32, 3, 2), 1),
-                    (zeros(1:5, Float32, (3, 2)), 0),
-                    (ones(1:5, Float32, (3, 2)), 1))
-        @test isa(A, Matrix{Float32}) && size(A) == (3,2) && all(x->x==val, A)
-    end
-    for (A,val) in ((zeros(1:5, Float32), 0),
-                    (ones(1:5, Float32), 1))
-        @test isa(A, Vector{Float32}) && size(A) == (5,) && all(x->x==val, A)
-    end
-end
-
 # PR 20203
 @test Compat.readline(IOBuffer("Hello, World!\n")) == "Hello, World!"
 @test Compat.readline(IOBuffer("x\n"), keep=false) == "x"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,22 +162,6 @@ for (t, s, m, kept) in [
     @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 end
 
-# PR 18727
-let
-    iset = Set([17, 4711])
-    cfset = convert(Set{Float64}, iset)
-    @test typeof(cfset) == Set{Float64}
-    @test cfset == iset
-    fset = Set([17.0, 4711.0])
-    ciset = convert(Set{Int}, fset)
-    @test typeof(ciset) == Set{Int}
-    @test ciset == fset
-    ssset = Set(split("foo bar"))
-    cssset = convert(Set{String}, ssset)
-    @test typeof(cssset) == Set{String}
-    @test cssset == Set(["foo", "bar"])
-end
-
 # PR 18082
 @test !isassigned(Ref{String}())
 @test isassigned(Ref{String}("Test"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,17 +180,7 @@ using Compat.Test
 @test (@__MODULE__) === Test22064
 end
 
-# invokelatest
-issue19774(x) = 1
-let foo() = begin
-        eval(:(issue19774(x::Int) = 2))
-        return Compat.invokelatest(issue19774, 0)
-    end
-    @test foo() == 2
-end
-cm359() = @__MODULE__
-@test Compat.invokelatest(cm359) === @__MODULE__
-
+# invokelatest with keywords
 pr22646(x; y=0) = 1
 let foo() = begin
         eval(:(pr22646(x::Int; y=0) = 2))


### PR DESCRIPTION
This should clean out the last bits from `src/Compat.jl` that have become irrelevant when requiring at least 0.6. (Unless I've missed anything, which is not unlikely). Also removes two (for some time) obsolete README entries. I'm also sure there are tests for stuff that has been removed, but double-testing Base functionality is not too bad, so I haven't gone through `runtests.jl` in detail.

(Should be squashed when merging; the commit messages themselves would be misleading without an appropriate heading.)