### PR TITLE
Make `range` definition depend on a `VERSION` check

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1850,7 +1850,7 @@ if VERSION < v"0.7.0-beta2.143"
     end
 end
 
-if VERSION ≤ v"1.0" || isempty(methods(range, Tuple{Any,Any}))
+if VERSION < v"1.1.0-DEV.506"
     range(start, stop; kwargs...) = range(start; stop=stop, kwargs...)
 end
 


### PR DESCRIPTION
At the time #633 was merged, the respective change was not in Julia, yet, so the `VERSION` to bound on wasn't known. I think, however, it's worth to change to easily know at what point we can drop this definition in the future.