### PR TITLE
Remove pre-0.6 code from deprecated.jl

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,19 +1,10 @@
 function depwarn_ex(msg, name)
     return quote
-        if VERSION >= v"0.6.0"
-            Base.depwarn($msg, Symbol($name))
-        end
+        Base.depwarn($msg, Symbol($name))
     end
 end
 
-function primarytype(@nospecialize(t))
-    tn = t.name
-    if isdefined(tn, :primary)
-        return tn.primary
-    else
-        return tn.wrapper
-    end
-end
+primarytype(@nospecialize(t)) = t.name.wrapper
 
 export @functorize
 macro functorize(f)
@@ -28,29 +19,16 @@ macro functorize(f)
     end
 end
 
-@static if VERSION >= v"0.6.0"
-    Base.@deprecate_binding KERNEL Sys.KERNEL
-    Base.@deprecate_binding UTF8String Core.String
-    Base.@deprecate_binding ASCIIString Core.String
-    Base.@deprecate_binding unsafe_convert Base.unsafe_convert
-    Base.@deprecate_binding remote_do Distributed.remote_do
-    Base.@deprecate_binding Filesystem Base.Filesystem
-    Base.@deprecate_binding AsyncCondition Base.AsyncCondition
-    Base.@deprecate_binding promote_eltype_op Base.promote_eltype_op
-    @eval Base.@deprecate_binding $(Symbol("@irrational")) Base.$(Symbol("@irrational"))
-    @eval Base.@deprecate_binding $(Symbol("@blasfunc")) Compat.LinearAlgebra.BLAS.$(Symbol("@blasfunc"))
-else
-    const KERNEL = Sys.KERNEL
-    const UTF8String = Core.String
-    const ASCIIString = Core.String
-    import Base.unsafe_convert
-    import Base.remote_do
-    import Base.Filesystem
-    import Base.AsyncCondition
-    import Base.promote_eltype_op
-    import Base.@irrational
-    import Base.LinAlg.BLAS.@blasfunc
-end
+Base.@deprecate_binding KERNEL Sys.KERNEL
+Base.@deprecate_binding UTF8String Core.String
+Base.@deprecate_binding ASCIIString Core.String
+Base.@deprecate_binding unsafe_convert Base.unsafe_convert
+Base.@deprecate_binding remote_do Distributed.remote_do
+Base.@deprecate_binding Filesystem Base.Filesystem
+Base.@deprecate_binding AsyncCondition Base.AsyncCondition
+Base.@deprecate_binding promote_eltype_op Base.promote_eltype_op
+@eval Base.@deprecate_binding $(Symbol("@irrational")) Base.$(Symbol("@irrational"))
+@eval Base.@deprecate_binding $(Symbol("@blasfunc")) Compat.LinearAlgebra.BLAS.$(Symbol("@blasfunc"))
 
 if VERSION < v"0.7.0-DEV.2915"
     const textwidth = Compat.Unicode.textwidth


### PR DESCRIPTION
AFAICT, we don't test the deprecated functionality, so a careful double-check by a second pair of eyes would be welcome.