### PR TITLE
Reflect moving of `textwidth` back to Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `IntSet` is now `BitSet` ([#24282])
 
+* `strwidth` and `charwidth` are now merged into `textwidth` ([#23667]).
+
 * `Complex32`, `Complex64`, and `Complex128` are now `ComplexF16`, `ComplexF32`, and
   `ComplexF64`, respectively ([#24647]).
 
@@ -470,6 +472,7 @@ includes this fix. Find the minimum version from there.
 [#23570]: https://github.com/JuliaLang/julia/issues/23570
 [#23642]: https://github.com/JuliaLang/julia/issues/23642
 [#23666]: https://github.com/JuliaLang/julia/issues/23666
+[#23667]: https://github.com/JuliaLang/julia/issues/23667
 [#23757]: https://github.com/JuliaLang/julia/issues/23757
 [#23805]: https://github.com/JuliaLang/julia/issues/23805
 [#23931]: https://github.com/JuliaLang/julia/issues/23931

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -889,6 +889,18 @@ else
     const tr = LinearAlgebra.trace
 end
 
+if VERSION < v"0.7.0-DEV.1930"
+    # no textwidth definition in Base
+    export textwidth
+    textwidth(c::Char) = charwidth(c)
+    textwidth(c::AbstractString) = strwidth(c)
+elseif v"0.7.0-DEV.2915" ≤ VERSION < v"0.7.0-DEV.3393"
+    # textwidth definition moved to Unicode module
+    import Unicode
+    const textwidth = Unicode.textwidth
+    export textwidth
+end
+
 # 0.7.0-DEV.2915
 module Unicode
     export graphemes, textwidth, isvalid,
@@ -897,10 +909,8 @@ module Unicode
            lowercase, uppercase, titlecase, lcfirst, ucfirst
 
     if VERSION < v"0.7.0-DEV.2915"
-        # 0.7.0-DEV.1930
-        if !isdefined(Base, :textwidth)
-            textwidth(c::Char) = charwidth(c)
-            textwidth(c::AbstractString) = strwidth(c)
+        if VERSION < v"0.7.0-DEV.1930"
+            import ..Compat: textwidth
         end
 
         isnumeric(c::Char) = isnumber(c)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -51,8 +51,3 @@ else
     import Base.@irrational
     import Base.LinAlg.BLAS.@blasfunc
 end
-
-if VERSION < v"0.7.0-DEV.2915"
-    const textwidth = Compat.Unicode.textwidth
-    export textwidth
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,8 +456,8 @@ end
 @test 1 in BitSet(1:10)
 
 # 0.7.0-DEV.1930
-@test Compat.Unicode.textwidth("A") == 1
-@test Compat.Unicode.textwidth('A') == 1
+@test textwidth("A") == 1
+@test textwidth('A') == 1
 
 # 0.7
 @test diagm(0 => ones(2), -1 => ones(2)) == [1.0 0.0 0.0; 1.0 1.0 0.0; 0.0 1.0 0.0]


### PR DESCRIPTION
`textwidth` was put back into Base in JuliaLang/julia#25479 which we hadn't properly reflected here, just had it accidentally correct thanks to the definition in `deprecated.jl`. I think this only actually makes a difference for `v"0.7.0-DEV.2915" ≤ VERSION < v"0.7.0-DEV.3393"`, where before this PR, `Compat.textwidth` is undefined (as is `Base.textwidth`). However, having a definition for non-deprecated functionality in `deprecated.jl` seems bad, and instead of just moving it, I've tried to make Compat a little bit more like Base here.