### PR TITLE
Remove old deprecations, deprecate obsolete stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,16 +366,6 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## New macros
 
-* `@vectorize_1arg` and `@vectorize_2arg` are deprecated on Julia 0.6 in favor
-  of the broadcast syntax ([#17302]). `Compat.@dep_vectorize_1arg` and
-  `Compat.@dep_vectorize_2arg` are provided so that packages can still provide
-  the deprecated definitions without causing a depwarn in the package itself
-  before all the users are upgraded.
-
-  Packages are expected to use this until all users of the deprecated
-  vectorized function have migrated. These macros will be dropped when the
-  support for `0.6` is dropped from `Compat`.
-
 * `@nospecialize` has been added ([#22666]).
 
 * The logging macros `@error`, `@warn`, `@info` and `@debug` can be used as
@@ -448,7 +438,6 @@ includes this fix. Find the minimum version from there.
 * Now specify the correct minimum version for Compat in your REQUIRE file by
 `Compat <version>`
 
-[#17302]: https://github.com/JuliaLang/julia/issues/17302
 [#20005]: https://github.com/JuliaLang/julia/issues/20005
 [#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21197]: https://github.com/JuliaLang/julia/issues/21197

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1427,13 +1427,6 @@ else
     round(x; digits = nothing, sigdigits = nothing, base = 10) = Base.round(x, digits = digits, sigdigits = sigdigits, base = base)
 end
 
-# compatibiltiy with https://github.com/JuliaLang/julia/pull/26156
-trunc(x, digits; base = 10) = trunc(x, digits = digits, base = base)
-floor(x, digits; base = 10) = floor(x, digits = digits, base = base)
-ceil(x, digits; base = 10) = ceil(x, digits = digits, base = base)
-round(x, digits; base = 10) = round(x, digits = digits, base = base)
-signif(x, digits; base = 10) = round(x, sigdigits = digits, base = base)
-
 # https://github.com/JuliaLang/julia/pull/25872
 if VERSION < v"0.7.0-DEV.3734"
     if isdefined(Base, :open_flags)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1814,16 +1814,17 @@ if VERSION < v"0.7.0-beta2.143"
     end
 end
 
-# This definition should be modified to throw an ArgumentError if neither
-# `step` nor `length` are given and be limited to VERSION < v"1.1.0-DEV.506".
-# However, there is a release with this definition, so we need to keep it around
-# to avoid breakage.
+function rangedepwarn(;step=nothing, length=nothing, kwargs...)
+    if step===nothing && length===nothing
+        Base.depwarn("`range(start, stop)` (with neither `length` nor `step` given) is deprecated, use `range(start, stop=stop)` instead.", :range)
+    end
+end
+
 if VERSION < v"1.1.0-DEV.506"
-    range(start, stop; kwargs...) = range(start; stop=stop, kwargs...)
-else
-    # This method is restricted to Number, since we don't
-    # want to overwrite the (::Any, ::Any) method in Base.
-    range(start::Number, stop::Number; kwargs...) = range(start; stop=stop, kwargs...)
+    function range(start, stop; kwargs...)
+        rangedepwarn(;kwargs...)
+        range(start; stop=stop, kwargs...)
+    end
 end
 
 include("deprecated.jl")

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -177,9 +177,6 @@ include("arraymacros.jl")
     readuntil(f, d::Vector{T}; keep::Bool = false) where {T<:Union{UInt8,Char}} = convert(Vector{T}, readuntil(f, String(d), keep=keep))
 end
 
-# TODO deprecate/remove this unexported binding (along wiht its tests)
-using Base: StringVector
-
 # https://github.com/JuliaLang/julia/pull/22646
 if VERSION < v"0.7.0-DEV.1139"
     function invokelatest(f, args...; kwargs...)
@@ -1533,7 +1530,7 @@ if VERSION < v"0.7.0-DEV.3734"
             buf = Base.IOBuffer(data, flags[1], flags[2], Int(maxsize))
         else
             size = sizehint !== nothing ? Int(sizehint) : maxsize != typemax(Int) ? Int(maxsize) : 32
-            buf = Base.IOBuffer(StringVector(size), flags[1], flags[2], Int(maxsize))
+            buf = Base.IOBuffer(Base.StringVector(size), flags[1], flags[2], Int(maxsize))
             buf.data[:] = 0
         end
         if flags[4] # flags.truncate

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -585,8 +585,6 @@ else
         if VERSION < v"0.7.0-DEV.3406"
             $((:(using Base.Random: $f) for f in random_fields)...)
             const seed! = Base.Random.srand
-            # these should be deprecated in favor of Compat.UUIDs.*
-            using Base.Random: uuid1, uuid4, uuid_version
         else
             $((:(using Random: $f) for f in random_fields)...)
             import Random
@@ -595,10 +593,14 @@ else
             else
                 using Random: seed!
             end
-            if VERSION < v"0.7.0-DEV.3666"
-                # these should be deprecated in favor of Compat.UUIDs.*
-                using Random: uuid1, uuid4, uuid_version
-            end
+        end
+        if VERSION < v"0.7.0-DEV.3666"
+            import ..Compat
+            Base.@deprecate uuid1() Compat.UUIDs.uuid1() false
+            Base.@deprecate uuid1(rng) Compat.UUIDs.uuid1(rng) false
+            Base.@deprecate uuid4() Compat.UUIDs.uuid4() false
+            Base.@deprecate uuid4(rng) Compat.UUIDs.uuid4(rng) false
+            Base.@deprecate uuid_version(u) Compat.UUIDs.uuid_version(u) false
         end
 
         gentype(args...) = eltype(args...)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -99,9 +99,6 @@ module TypeUtils
     export isabstract, parameter_upper_bound, typename
 end # module TypeUtils
 
-# @view, @views, @__dot__
-include("arraymacros.jl")
-
 # https://github.com/JuliaLang/julia/pull/25646
 @static if VERSION < v"0.7.0-DEV.3510"
     # not exported

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -87,61 +87,6 @@ end
         eval(mod, :(include_string($code, $fname)))
 end
 
-# PR #17302
-# Provide a non-deprecated version of `@vectorize_(1|2)arg` macro which defines
-# deprecated version of the function so that the depwarns can be fixed without
-# breaking users.
-# Packages are expected to use this to maintain the old API until all users
-# of the deprecated vectorized function have migrated.
-# These macros should raise a depwarn when the `0.5` support is dropped from
-# `Compat` and be dropped when the support for `0.6` is dropped from `Compat`.
-# Modified based on the version copied from 0.6 Base.
-if VERSION < v"0.7.0-DEV.1211"
-    macro dep_vectorize_1arg(S, f)
-        S = esc(S)
-        f = esc(f)
-        T = esc(:T)
-        x = esc(:x)
-        AbsArr = esc(:AbstractArray)
-        ## Depwarn to be enabled when 0.5 support is dropped.
-        # depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
-        #         Symbol("@dep_vectorize_1arg"))
-        :(@deprecate $f{$T<:$S}($x::$AbsArr{$T}) @compat($f.($x)))
-    end
-
-    macro dep_vectorize_2arg(S, f)
-        S = esc(S)
-        f = esc(f)
-        T1 = esc(:T1)
-        T2 = esc(:T2)
-        x = esc(:x)
-        y = esc(:y)
-        AbsArr = esc(:AbstractArray)
-        ## Depwarn to be enabled when 0.5 support is dropped.
-        # depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
-        #         Symbol("@dep_vectorize_2arg"))
-        quote
-            @deprecate $f{$T1<:$S}($x::$S, $y::$AbsArr{$T1}) @compat($f.($x,$y))
-            @deprecate $f{$T1<:$S}($x::$AbsArr{$T1}, $y::$S) @compat($f.($x,$y))
-            @deprecate $f{$T1<:$S,$T2<:$S}($x::$AbsArr{$T1}, $y::$AbsArr{$T2}) @compat($f.($x,$y))
-        end
-    end
-else
-    macro dep_vectorize_1arg(S, f)
-        AbstractArray = GlobalRef(Base, :AbstractArray)
-        return esc(:(@deprecate $f(x::$AbstractArray{T}) where {T<:$S} $f.(x)))
-    end
-
-    macro dep_vectorize_2arg(S, f)
-        AbstractArray = GlobalRef(Base, :AbstractArray)
-        return esc(quote
-            @deprecate $f(x::$S, y::$AbstractArray{T1}) where {T1<:$S} $f.(x, y)
-            @deprecate $f(x::$AbstractArray{T1}, y::$S) where {T1<:$S} $f.(x, y)
-            @deprecate $f(x::$AbstractArray{T1}, y::$AbstractArray{T2}) where {T1<:$S, T2<:$S} $f.(x, y)
-        end)
-    end
-end
-
 @static if !isdefined(Base, :isabstracttype) # VERSION < v"0.7.0-DEV.3475"
     const isabstracttype = Base.isabstract
     export isabstracttype

--- a/src/arraymacros.jl
+++ b/src/arraymacros.jl
@@ -1,7 +1,0 @@
-# TODO deprecate
-# this was defined for use with Julia versions prior to 0.5
-# (see https://github.com/JuliaLang/Compat.jl/pull/316)
-macro dotcompat(x)
-    esc(_compat(Base.Broadcast.__dot__(x)))
-end
-export @dotcompat

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -56,6 +56,13 @@ else
     end
 end
 
+# compatibility with https://github.com/JuliaLang/julia/pull/26156
+Base.@deprecate trunc(x, digits; base = 10) Compat.trunc(x, digits = digits, base = base) false
+Base.@deprecate floor(x, digits; base = 10) Compat.floor(x, digits = digits, base = base) false
+Base.@deprecate ceil(x, digits; base = 10) Compat.ceil(x, digits = digits, base = base) false
+Base.@deprecate round(x, digits; base = 10) Compat.round(x, digits = digits, base = base) false
+Base.@deprecate signif(x, digits; base = 10) Compat.round(x, sigdigits = digits, base = base) false
+
 # to be deprecated:
 
 # * `range(start, stop)` (without either `length` nor `step` given)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -73,6 +73,14 @@ if VERSION >= v"1.1.0-DEV.506"
     end
 end
 
+# this was defined for use with Julia versions prior to 0.5
+# (see https://github.com/JuliaLang/Compat.jl/pull/316)
+macro dotcompat(x)
+    Base.depwarn("`@dotcompat x` is deprecated, use `@compat @. x` instead.", Symbol("@dotcompat"))
+    esc(:(Compat.@compat @. $x))
+end
+export @dotcompat
+
 # to be deprecated:
 
 # * Compat.Random.uuid1, uuid4, uuid_version (in favour of Compat.UUIDs.*)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -63,7 +63,16 @@ Base.@deprecate ceil(x, digits; base = 10) Compat.ceil(x, digits = digits, base 
 Base.@deprecate round(x, digits; base = 10) Compat.round(x, digits = digits, base = base) false
 Base.@deprecate signif(x, digits; base = 10) Compat.round(x, sigdigits = digits, base = base) false
 
+if VERSION >= v"1.1.0-DEV.506"
+    # deprecation of range(start, stop) for earlier versions is done in Compat.jl
+    # This method is restricted to Number, since we don't
+    # want to overwrite the (::Any, ::Any) method in Base.
+    function range(start::Number, stop::Number; kwargs...)
+        rangedepwarn(;kwargs...)
+        range(start; stop=stop, kwargs...)
+    end
+end
+
 # to be deprecated:
 
-# * `range(start, stop)` (without either `length` nor `step` given)
 # * Compat.Random.uuid1, uuid4, uuid_version (in favour of Compat.UUIDs.*)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,61 @@
 Base.@deprecate_binding StringVector Base.StringVector false
 
+# PR #17302
+# Provide a non-deprecated version of `@vectorize_(1|2)arg` macro which defines
+# deprecated version of the function so that the depwarns can be fixed without
+# breaking users.
+# Packages are expected to use this to maintain the old API until all users
+# of the deprecated vectorized function have migrated.
+# These macros should be dropped when the support for `0.6` is dropped from `Compat`.
+# Modified based on the version copied from 0.6 Base.
+if VERSION < v"0.7.0-DEV.1211"
+    macro dep_vectorize_1arg(S, f)
+        S = esc(S)
+        f = esc(f)
+        T = esc(:T)
+        x = esc(:x)
+        AbsArr = esc(:AbstractArray)
+        Base.depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+            Symbol("@dep_vectorize_1arg"))
+        :(@deprecate $f{$T<:$S}($x::$AbsArr{$T}) @compat($f.($x)))
+    end
+
+    macro dep_vectorize_2arg(S, f)
+        S = esc(S)
+        f = esc(f)
+        T1 = esc(:T1)
+        T2 = esc(:T2)
+        x = esc(:x)
+        y = esc(:y)
+        AbsArr = esc(:AbstractArray)
+        Base.depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+            Symbol("@dep_vectorize_2arg"))
+        quote
+            @deprecate $f{$T1<:$S}($x::$S, $y::$AbsArr{$T1}) @compat($f.($x,$y))
+            @deprecate $f{$T1<:$S}($x::$AbsArr{$T1}, $y::$S) @compat($f.($x,$y))
+            @deprecate $f{$T1<:$S,$T2<:$S}($x::$AbsArr{$T1}, $y::$AbsArr{$T2}) @compat($f.($x,$y))
+        end
+    end
+else
+    macro dep_vectorize_1arg(S, f)
+        AbstractArray = GlobalRef(Base, :AbstractArray)
+        Base.depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+            Symbol("@dep_vectorize_1arg"))
+        return esc(:(@deprecate $f(x::$AbstractArray{T}) where {T<:$S} $f.(x)))
+    end
+
+    macro dep_vectorize_2arg(S, f)
+        AbstractArray = GlobalRef(Base, :AbstractArray)
+        Base.depwarn("Implicit vectorized function is deprecated in favor of compact broadcast syntax.",
+            Symbol("@dep_vectorize_2arg"))
+        return esc(quote
+            @deprecate $f(x::$S, y::$AbstractArray{T1}) where {T1<:$S} $f.(x, y)
+            @deprecate $f(x::$AbstractArray{T1}, y::$S) where {T1<:$S} $f.(x, y)
+            @deprecate $f(x::$AbstractArray{T1}, y::$AbstractArray{T2}) where {T1<:$S, T2<:$S} $f.(x, y)
+        end)
+    end
+end
+
 # to be deprecated:
 
 # * `range(start, stop)` (without either `length` nor `step` given)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -81,6 +81,4 @@ macro dotcompat(x)
 end
 export @dotcompat
 
-# to be deprecated:
-
-# * Compat.Random.uuid1, uuid4, uuid_version (in favour of Compat.UUIDs.*)
+# Compat.Random.uuid1, uuid4, uuid_version are deprecated in Compat.jl

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,5 @@
+Base.@deprecate_binding StringVector Base.StringVector false
+
 # to be deprecated:
 
 # * `range(start, stop)` (without either `length` nor `step` given)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,35 +1,3 @@
-function depwarn_ex(msg, name)
-    return quote
-        Base.depwarn($msg, Symbol($name))
-    end
-end
-
-primarytype(@nospecialize(t)) = t.name.wrapper
-
-export @functorize
-macro functorize(f)
-    code = f === :scalarmax          ? :(Base.scalarmax) :
-           f === :scalarmin          ? :(Base.scalarmin) :
-           f === :centralizedabs2fun ? :(primarytype(typeof(Base.centralizedabs2fun(0)))) :
-           f
-    warning = depwarn_ex("@functorize is deprecated as functor objects are no longer supported in julia", "@functorize")
-    return quote
-        $warning
-        $code
-    end
-end
-
-Base.@deprecate_binding KERNEL Sys.KERNEL
-Base.@deprecate_binding UTF8String Core.String
-Base.@deprecate_binding ASCIIString Core.String
-Base.@deprecate_binding unsafe_convert Base.unsafe_convert
-Base.@deprecate_binding remote_do Distributed.remote_do
-Base.@deprecate_binding Filesystem Base.Filesystem
-Base.@deprecate_binding AsyncCondition Base.AsyncCondition
-Base.@deprecate_binding promote_eltype_op Base.promote_eltype_op
-@eval Base.@deprecate_binding $(Symbol("@irrational")) Base.$(Symbol("@irrational"))
-@eval Base.@deprecate_binding $(Symbol("@blasfunc")) Compat.LinearAlgebra.BLAS.$(Symbol("@blasfunc"))
-
 # to be deprecated:
 
 # * `range(start, stop)` (without either `length` nor `step` given)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,17 +165,6 @@ for (t, s, m, kept) in [
     @test Compat.readuntil(IOBuffer(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 end
 
-# PR 19449
-# TODO remove these tests when Compat.StringVector is deprecated
-using Compat: StringVector
-@test length(StringVector(5)) == 5
-@test String(fill!(StringVector(5), 0x61)) == "aaaaa"
-let x = fill!(StringVector(5), 0x61)
-    # 0.7
-    @test pointer(x) == pointer(String(x))
-end
-
-
 # PR 22064
 module Test22064
 using Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,30 +16,6 @@ for os in [:apple, :bsd, :linux, :unix, :windows]
     @eval @test Compat.Sys.$(Symbol("is", os))() == $from_base()
 end
 
-# PR #17302
-# To be removed when 0.6 support is dropped.
-f17302(a::Number) = a
-f17302(a::Number, b::Number) = a + b
-Compat.@dep_vectorize_1arg Real f17302
-Compat.@dep_vectorize_2arg Real f17302
-@test_throws MethodError f17302([1im])
-@test_throws MethodError f17302([1im], [1im])
-@static if VERSION ≥ v"0.7.0-DEV.2988"
-    @test (@test_logs (:warn, "`f17302(x::(Base.AbstractArray){T}) where T <: Real` is deprecated, use `f17302.(x)` instead.") f17302([1.0])) == [1.0]
-    @test (@test_logs (:warn, "`f17302(x::Real, y::(Base.AbstractArray){T1}) where T1 <: Real` is deprecated, use `f17302.(x, y)` instead.") f17302(1.0, [1])) == [2.0]
-    @test (@test_logs (:warn, "`f17302(x::(Base.AbstractArray){T1}, y::Real) where T1 <: Real` is deprecated, use `f17302.(x, y)` instead.") f17302([1.0], 1)) == [2.0]
-    @test (@test_logs (:warn, "`f17302(x::(Base.AbstractArray){T1}, y::(Base.AbstractArray){T2}) where {T1 <: Real, T2 <: Real}` is deprecated, use `f17302.(x, y)` instead.") f17302([1.0], [1])) == [2.0]
-else
-    mktemp() do fname, f
-        redirect_stderr(f) do
-            @test f17302([1.0]) == [1.0]
-            @test f17302(1.0, [1]) == [2.0]
-            @test f17302([1.0], 1) == [2.0]
-            @test f17302([1.0], [1]) == [2.0]
-        end
-    end
-end
-
 let s = "Koala test: 🐨"
     @test transcode(UInt16, s) == UInt16[75,111,97,108,97,32,116,101,115,116,58,32,55357,56360]
     @test transcode(UInt32, s) == UInt32[75,111,97,108,97,32,116,101,115,116,58,32,128040]
@@ -93,36 +69,6 @@ eval(Expr(
 @test !isabstracttype(ConcreteFoo20006N)
 @test !isabstracttype(ConcreteFoo200061)
 @test !isabstracttype(StridedArray)
-
-# TODO remove these tests when deprecating @dotcompat
-let X = reshape(1:24,2,3,4)
-    @test X[1:end] == @dotcompat (@view X[1:end]) # test compatibility of @. and @view
-    @views let
-        x = [5,8,7,4]
-        @dotcompat x[([3],)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
-        @test x == [5,8,10,4]
-        @dotcompat x[3:end] = 0       # make sure @. works with end expressions in @views
-        @test x == [5,8,0,0]
-    end
-end
-# @. (@__dot__) tests, from base:
-let x = [4, -9, 1, -16]
-    @test [2, 3, 4, 5] == @dotcompat(1 + sqrt($sort(abs(x))))
-    @test @dotcompat(x^2) == x.^2
-    @dotcompat x = 2
-    @test x == [2,2,2,2]
-end
-@test [1,4,9] == @dotcompat let x = [1,2,3]; x^2; end
-let x = [1,2,3], y = x
-    @dotcompat for i = 1:3
-        y = y^2 # should convert to y .= y.^2
-    end
-    @test x == [1,256,6561]
-end
-let x = [1,2,3]
-    @dotcompat f(x) = x^2
-    @test f(x) == [1,4,9]
-end
 
 # PR 20203
 @test Compat.readline(IOBuffer("Hello, World!\n")) == "Hello, World!"
@@ -967,13 +913,6 @@ module TestNames
 end
 @test :foo in Compat.names(TestNames)
 @test :bar in Compat.names(TestNames, all=true)
-
-# 0.7.0-DEV.4062, but dropped in 0.7.0-DEV.4804
-@test Compat.trunc(pi, 3, base = 2) == 3.125
-@test Compat.floor(pi, 3, base = 2) == 3.125
-@test Compat.ceil(pi, 3, base = 2) == 3.25
-@test Compat.round(pi, 3, base = 2) == 3.125
-@test Compat.signif(pi, 5, base = 10) == 3.1416
 
 # 0.7.0-DEV.4804
 @test Compat.trunc(pi) == 3.0


### PR DESCRIPTION
Closes #640, which was the motivation to do this: When doing a breaking change, why not do all pending ones at once (in anticipation of the required major version bump).

Note that the removed tests passed with the deprecations in place (i.e. run against ~666460f~ 
~dc73ae6~ 80afcef).