### PR TITLE
Add missing members to `Compat.Random`

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -646,6 +646,8 @@ else
         if VERSION < v"0.7.0-DEV.3406"
             $((:(using Base.Random: $f) for f in random_fields)...)
             const seed! = Base.Random.srand
+            # these should be deprecated in favor of Compat.UUIDs.*
+            using Base.Random: uuid1, uuid4, uuid_version
         else
             $((:(using Random: $f) for f in random_fields)...)
             import Random
@@ -653,6 +655,10 @@ else
                 const seed! = Random.srand
             else
                 using Random: seed!
+            end
+            if VERSION < v"0.7.0-DEV.3666"
+                # these should be deprecated in favor of Compat.UUIDs.*
+                using Random: uuid1, uuid4, uuid_version
             end
         end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -632,12 +632,16 @@ end
 if VERSION >= v"0.7.0-beta.234"
     import Random
 else
-    const random_fields = [
+    const exported_random_fields = [
         :AbstractRNG, :MersenneTwister, :RandomDevice, :bitrand, :rand, :rand!,
         :randcycle, :randexp, :randexp!, :randjump, :randn!,
         :randperm, :randstring, :randsubseq, :randsubseq!, :shuffle,
         :shuffle!
     ]
+    const unexported_random_fields = [
+        :GLOBAL_RNG, :RangeGenerator
+    ]
+    const random_fields = [exported_random_fields; unexported_random_fields]
     @eval module Random
         if VERSION < v"0.7.0-DEV.3406"
             $((:(using Base.Random: $f) for f in random_fields)...)
@@ -654,7 +658,7 @@ else
 
         gentype(args...) = eltype(args...)
 
-        export $(random_fields...)
+        export $(exported_random_fields...)
     end
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -33,3 +33,4 @@ Base.@deprecate_binding promote_eltype_op Base.promote_eltype_op
 # to be deprecated:
 
 # * `range(start, stop)` (without either `length` nor `step` given)
+# * Compat.Random.uuid1, uuid4, uuid_version (in favour of Compat.UUIDs.*)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1505,6 +1505,7 @@ Random.seed!(1)
 rng = MersenneTwister(0)
 Random.seed!(rng, 1)
 @test rand(rng) ≈ 0.23603334566204692
+@test 0 < rand(Random.GLOBAL_RNG, Random.RangeGenerator(1:3)) < 4
 
 # 0.7.0-beta2.169
 @test floatmin(Float16) == @eval $(Core.Intrinsics.bitcast(Float16, 0x0400))


### PR DESCRIPTION
These (EDIT: `Random.RangeGenerator` and `Random.GLOBAL_RNG`) are used (at least) by `StatsBase`. A more thorough fix would probably include #440, but I'd like to get back to a usable state quickly.

CC @rdeits, @malmaud