### PR TITLE
EachRow/EachCol types (see #32310)

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1903,6 +1903,17 @@ if v"0.7.0" <= VERSION < v"1.3.0-alpha.8"
     Base.mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)
 end
 
+# https://github.com/JuliaLang/julia/pull/32310
+if v"0.7.0" <= VERSION
+    const EachRow{A,I} = Union{Base.Generator{I,(typeof(eachrow(ones(Int32,2,2)).f).name.wrapper){A}}, Base.Generator{I,(typeof(eachrow(ones(Int32,2,2)).f).name.wrapper){A}}
+    const EachCol{A,I} = Base.Generator{I,(typeof(eachcol(ones(Int32,2,2)).f).name.wrapper){A}}
+                               
+    Base.parent(x::EachRow) = x.f.A
+    Base.parent(x::EachCol) = x.f.A
+end    
+
+
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1554,4 +1554,17 @@ if VERSION >= v"0.7"
     end
 end
 
+if VERSION >= v"0.7"
+    @testset "EachRow/EachSlice" begin
+        X = rand(3,3)
+        @test eachrow(X) isa EachRow
+        @test !(eachcol(X) isa EachRow)
+        @test eachcol(X) isa EachCol
+        @test !(eachrow(X) isa EachCol)
+
+        @test parent(eachrow(X)) === X
+        @test parent(eachcol(X)) === X
+    end
+end
+
 nothing


### PR DESCRIPTION
Obviously still needs the PR to be merged, but this is just to show we can monkey-patch the aliases to support older versions of Julia.

cc: @nalimilan 