### PR TITLE
Add ASCII alias `compose` of `∘` (JuliaLang/julia#33573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 ## Other changes
 
+* Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
+  and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).
+
 ## New types
 
 ## Developer tips
@@ -127,3 +130,4 @@ includes this fix. Find the minimum version from there.
 [#29749]: https://github.com/JuliaLang/julia/issues/29749
 [#32628]: https://github.com/JuliaLang/julia/issues/32628
 [#33129]: https://github.com/JuliaLang/julia/issues/33129
+[#33568]: https://github.com/JuliaLang/julia/pull/33568

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `merge` methods with one and `n` `NamedTuple`s ([#29259]).
 
+* Function composition `∘` now has an ASCII alias `compose` ([#33573]).
+
 ## Renaming
 
 ## New macros
@@ -131,3 +133,4 @@ includes this fix. Find the minimum version from there.
 [#32628]: https://github.com/JuliaLang/julia/issues/32628
 [#33129]: https://github.com/JuliaLang/julia/issues/33129
 [#33568]: https://github.com/JuliaLang/julia/pull/33568
+[#33573]: https://github.com/JuliaLang/julia/pull/33573

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -88,6 +88,11 @@ if VERSION < v"1.3.0-alpha.8"
     Base.mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)
 end
 
+# https://github.com/JuliaLang/julia/pull/33568
+if VERSION < v"1.4.0-DEV.329"
+    Base.:∘(f, g, h...) = ∘(f ∘ g, h...)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -93,6 +93,12 @@ if VERSION < v"1.4.0-DEV.329"
     Base.:∘(f, g, h...) = ∘(f ∘ g, h...)
 end
 
+# https://github.com/JuliaLang/julia/pull/33573
+if VERSION < v"1.4.0-DEV.330"
+    export compose
+    const compose = ∘
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,10 +91,12 @@ end
 end
 
 # https://github.com/JuliaLang/julia/pull/33568
+# https://github.com/JuliaLang/julia/pull/33573
 @testset "function composition" begin
     @test ∘(x -> x-2, x -> x-3, x -> x+5)(7) == 7
     fs = [x -> x[1:2], uppercase, lowercase]
     @test ∘(fs...)("ABC") == "AB"
+    @test ∘(fs...) === compose(fs...)
 end
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,4 +90,11 @@ end
     @test_throws DivideError mod(3, 1:0)
 end
 
+# https://github.com/JuliaLang/julia/pull/33568
+@testset "function composition" begin
+    @test ∘(x -> x-2, x -> x-3, x -> x+5)(7) == 7
+    fs = [x -> x[1:2], uppercase, lowercase]
+    @test ∘(fs...)("ABC") == "AB"
+end
+
 nothing


### PR DESCRIPTION
Backport https://github.com/JuliaLang/julia/pull/33573

Waiting for:
- [ ] https://github.com/JuliaLang/julia/pull/33573
- [x] #668