### PR TITLE
Rewrite the deprecation of `parameter_upper_bound`

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -31,6 +31,10 @@ Base.@deprecate enable_debug(x::Bool) x false
 module TypeUtils
     Base.@deprecate_binding isabstract isabstracttype
     Base.@deprecate_binding typename Base.typename
-    Base.@deprecate_binding parameter_upper_bound Base.parameter_upper_bound
+    Base.@pure function _parameter_upper_bound(t::UnionAll, idx)
+        return Base.rewrap_unionall((Base.unwrap_unionall(t)::DataType).parameters[idx], t)
+    end
+    Base.@deprecate_binding(parameter_upper_bound, _parameter_upper_bound, true,
+        ", rewrite your code to use static parameters in dispatch or use `Base.rewrap_unionall((Base.unwrap_unionall(t)::DataType).parameters[idx], t)`.")
 end # module TypeUtils
 Base.@deprecate_binding TypeUtils TypeUtils false ", call the respective Base functions directly"


### PR DESCRIPTION
This replaces the call to the internal `Base.parameter_upper_bound` with its definition. As the function needs to be pure, it has to use `@depreate_binding`, with the actual replacement hidden in an internal function and a customized deprecation message.

Example output:
```julia
julia> Compat.TypeUtils.parameter_upper_bound(Array, 1)
WARNING: Compat.TypeUtils is deprecated, call the respective Base functions directly
 in module Compat
WARNING: TypeUtils.parameter_upper_bound is deprecated, rewrite your code to use static parameters in dispatch or use `Base.rewrap_unionall((Base.unwrap_unionall(t)::DataType).parameters[idx], t)`.
 in module TypeUtils
Any
```

The small downside to using `@depreate_binding` is that the first part of the message says just `TypeUtils.parameter_upper_bound`, not `TypeUtils.parameter_upper_bound(t, idx)`, but that doesn't seem too bad.

Replaces #660.