### PR TITLE
Reorder (and restructure) the sections in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ the syntax on Julia `master`. However, in a few cases where this is not possible
 a slightly different syntax might be used.
 Please check the list below for the specific syntax you need.
 
-## Supported syntax
-
-Currently, the `@compat` macro supports the following syntaxes:
-
-## Module Aliases
-
-## New functions, macros, and methods
+## Supported features
 
 * `only(x)` returns the one-and-only element of a collection `x` ([#33129]). (since Compat 2.2.0)
 
@@ -67,16 +61,8 @@ Currently, the `@compat` macro supports the following syntaxes:
 
 * `Base.Order.ReverseOrdering` has a zero arg constructor [#33736]. (since Compat 3.0.0)
 
-## Renaming
-
-## New macros
-
-## Other changes
-
 * Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
   and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).  (since Compat 3.0.0)
-
-## New types
 
 ## Developer tips
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `Base.Order.ReverseOrdering` has a zero arg constructor [#33736]. (since Compat 3.0.0)
+
+* Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
+  and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).  (since Compat 3.0.0)
+
 * `only(x)` returns the one-and-only element of a collection `x` ([#33129]). (since Compat 2.2.0)
 
 * `mod` now accepts a unit range as the second argument ([#32628]). (since Compat 2.2.0)
@@ -53,16 +58,11 @@ Please check the list below for the specific syntax you need.
 
 * `isnothing` for testing if a variable is equal to `nothing` ([#29674]).  (since Compat 2.1.0)
 
-* `range` supporting `stop` as positional argument ([#28708]). (since Compat 1.3.0)
-
 * `hasproperty` and `hasfield` ([#28850]).  (since Compat 2.0.0)
 
 * `merge` methods with one and `n` `NamedTuple`s ([#29259]). (since Compat 2.0.0)
 
-* `Base.Order.ReverseOrdering` has a zero arg constructor [#33736]. (since Compat 3.0.0)
-
-* Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
-  and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).  (since Compat 3.0.0)
+* `range` supporting `stop` as positional argument ([#28708]). (since Compat 1.3.0)
 
 ## Developer tips
 


### PR DESCRIPTION
Previously, the sections were
* Supported syntax
* Module Aliases
* New functions, macros, and methods
* Renaming
* New macros
* Other changes
* New types
* Developer tips

This changes the order to
* Supported syntax
* New functions and methods
* New macros
* New types
* Renaming
* Other changes
* Developer tips

getting rid of the ambiguity where to put new macros and removing the 
"Module Aliases" section (if needed, these could probably go into 
"Renaming").

Also, the entry from #668 is moved from "Other changes" to "New 
functions and methods" as it is a new method.

Finally, presently empty sections get a "None." placeholder entry.