### PR TITLE
Support fancy CartesianIndex operations on Julia 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.4.0"
+version = "3.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `I1:I2`, when `I1` and `I2` are CartesianIndex values, constructs a CartesianIndices
+  iterator ([#29440]). (Since Compat 3.5.0)
+
+* `oneunit(::CartesianIndex)` replaces `one(::CartesianIndex)` ([#29442]). (Since Compat 3.5.0)
+
 * `ismutable` return `true` iff value `v` is mutable ([#34652]). (since Compat 3.4.0)
 
 * `uuid5` generates a version 5 universally unique identifier (UUID), as specified by RFC 4122 ([#28761]). (since Compat 3.3.0)
@@ -108,6 +113,8 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#28708]: https://github.com/JuliaLang/julia/issues/28708
 [#28850]: https://github.com/JuliaLang/julia/issues/28850
 [#29259]: https://github.com/JuliaLang/julia/issues/29259
+[#29440]: https://github.com/JuliaLang/julia/pull/29440
+[#29442]: https://github.com/JuliaLang/julia/pull/29442
 [#29674]: https://github.com/JuliaLang/julia/issues/29674
 [#29749]: https://github.com/JuliaLang/julia/issues/29749
 [#32628]: https://github.com/JuliaLang/julia/issues/32628

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -5,6 +5,18 @@ using LinearAlgebra: Adjoint, Diagonal, Transpose, UniformScaling, RealHermSymCo
 
 include("compatmacro.jl")
 
+# https://github.com/JuliaLang/julia/pull/29440
+if VERSION < v"1.1.0-DEV.389"
+    Base.:(:)(I::CartesianIndex{N}, J::CartesianIndex{N}) where N =
+        CartesianIndices(map((i,j) -> i:j, Tuple(I), Tuple(J)))
+end
+
+# https://github.com/JuliaLang/julia/pull/29442
+if VERSION < v"1.1.0-DEV.403"
+    Base.oneunit(::CartesianIndex{N}) where {N} = oneunit(CartesianIndex{N})
+    Base.oneunit(::Type{CartesianIndex{N}}) where {N} = CartesianIndex(ntuple(x -> 1, Val(N)))
+end
+
 # https://github.com/JuliaLang/julia/pull/29679
 if VERSION < v"1.1.0-DEV.472"
     export isnothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,14 @@ using UUIDs: UUID, uuid1, uuid_version
 
 @test isempty(detect_ambiguities(Base, Core, Compat))
 
+@testset "CartesianIndex" begin
+    # https://github.com/JuliaLang/julia/pull/29440
+    ci = CartesianIndex(1, 1)
+    @test length(-ci:ci) == 9
+    # https://github.com/JuliaLang/julia/pull/29442
+    @test oneunit(ci) === ci
+end
+
 # julia#29679
 @test !isnothing(1)
 @test isnothing(nothing)
@@ -219,7 +227,7 @@ end
 @testset "ismutable" begin
     @test ismutable(1) == false
     @test ismutable([]) == true
-end             
+end
 
 # https://github.com/JuliaLang/julia/pull/28761
 @testset "uuid5" begin


### PR DESCRIPTION
This supports the code in https://julialang.org/blog/2016/02/iteration/

This has started becoming an issue, e.g., https://github.com/JuliaImages/ImageMorphology.jl/pull/24