### PR TITLE
Add support for `evalpoly` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.6.0"
+version = "3.7.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `evalpoly(x, (p1, p2, ...))`, the function equivalent to `@evalpoly(x, p1, p2, ...)`
+  ([#32753]). (since Compat 3.7.0)
+
 * `zero(::Irrational)` and `one` now defined ([#34773]). (since Compat 3.6.0)
 
 * `I1:I2`, when `I1` and `I2` are CartesianIndex values, constructs a CartesianIndices
@@ -122,6 +125,7 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#29749]: https://github.com/JuliaLang/julia/issues/29749
 [#32628]: https://github.com/JuliaLang/julia/issues/32628
 [#32739]: https://github.com/JuliaLang/julia/issues/32739
+[#32753]: https://github.com/JuliaLang/julia/issues/32753
 [#32968]: https://github.com/JuliaLang/julia/issues/32968
 [#33128]: https://github.com/JuliaLang/julia/issues/33128
 [#33129]: https://github.com/JuliaLang/julia/issues/33129

--- a/README.md
+++ b/README.md
@@ -113,19 +113,19 @@ Note that you should specify the correct minimum version for `Compat` in the
 `[compat]` section of your `Project.toml`, as given in above list.
 
 [#28708]: https://github.com/JuliaLang/julia/issues/28708
+[#28761]: https://github.com/JuliaLang/julia/issues/28761
 [#28850]: https://github.com/JuliaLang/julia/issues/28850
 [#29259]: https://github.com/JuliaLang/julia/issues/29259
-[#29440]: https://github.com/JuliaLang/julia/pull/29440
-[#29442]: https://github.com/JuliaLang/julia/pull/29442
+[#29440]: https://github.com/JuliaLang/julia/issues/29440
+[#29442]: https://github.com/JuliaLang/julia/issues/29442
 [#29674]: https://github.com/JuliaLang/julia/issues/29674
 [#29749]: https://github.com/JuliaLang/julia/issues/29749
 [#32628]: https://github.com/JuliaLang/julia/issues/32628
-[#32739]: https://github.com/JuliaLang/julia/pull/32739
+[#32739]: https://github.com/JuliaLang/julia/issues/32739
+[#32968]: https://github.com/JuliaLang/julia/issues/32968
+[#33128]: https://github.com/JuliaLang/julia/issues/33128
 [#33129]: https://github.com/JuliaLang/julia/issues/33129
-[#33568]: https://github.com/JuliaLang/julia/pull/33568
-[#33128]: https://github.com/JuliaLang/julia/pull/33128
-[#33736]: http://github.com/JuliaLang/julia/pull/33736
-[#32968]: https://github.com/JuliaLang/julia/pull/32968
-[#28761]: https://github.com/JuliaLang/julia/pull/28761
-[#34652]: https://github.com/JuliaLang/julia/pull/34652
-[#34773]: https://github.com/JuliaLang/julia/pull/34773
+[#33568]: https://github.com/JuliaLang/julia/issues/33568
+[#33736]: https://github.com/JuliaLang/julia/issues/33736
+[#34652]: https://github.com/JuliaLang/julia/issues/34652
+[#34773]: https://github.com/JuliaLang/julia/issues/34773

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,4 +279,23 @@ end
     @test zero(typeof(pi)) === false
 end
 
+# https://github.com/JuliaLang/julia/pull/32753
+@testset "evalpoly real" begin
+    for x in -1.0:2.0, p1 in -3.0:3.0, p2 in -3.0:3.0, p3 in -3.0:3.0
+        evpm = @evalpoly(x, p1, p2, p3)
+        @test evalpoly(x, (p1, p2, p3)) == evpm
+        @test evalpoly(x, [p1, p2, p3]) == evpm
+    end
+end
+@testset "evalpoly complex" begin
+    for x in -1.0:2.0, y in -1.0:2.0, p1 in -3.0:3.0, p2 in -3.0:3.0, p3 in -3.0:3.0
+        z = x + im * y
+        evpm = @evalpoly(z, p1, p2, p3)
+        @test evalpoly(z, (p1, p2, p3)) == evpm
+        @test evalpoly(z, [p1, p2, p3]) == evpm
+    end
+    @test evalpoly(1+im, (2,)) == 2
+    @test evalpoly(1+im, [2,]) == 2
+end
+
 nothing


### PR DESCRIPTION
Code copied from https://github.com/JuliaLang/julia/pull/32753.

I've used `NEWS-update.jl` to add the correct link to the README—which made me notice that the links have become quite inconsistently styled. So I've included a commit which normalizes them to the form produced by `NEWS-update.jl`. I hope nobody objects to this touching quite a few lines without any real benefit. (Also, I think mentioning `NEWS-update.jl` in the "Developer tips" section of the README would make sense, if anyone feels like it...)

This includes a version bump to 3.7.0 for immediate tagging of a new release.