### PR TITLE
Add at-NamedTuple macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.7.0"
+version = "3.8.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `@NamedTuple` macro for convenient `struct`-like syntax for declaring
+`NamedTuple` types via `key::Type` declarations ([#34548]). (since Compat 3.8.0)
+
 * `evalpoly(x, (p1, p2, ...))`, the function equivalent to `@evalpoly(x, p1, p2, ...)`
   ([#32753]). (since Compat 3.7.0)
 
@@ -131,5 +134,6 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#33129]: https://github.com/JuliaLang/julia/issues/33129
 [#33568]: https://github.com/JuliaLang/julia/issues/33568
 [#33736]: https://github.com/JuliaLang/julia/issues/33736
+[#34548]: https://github.com/JuliaLang/julia/pull/34548
 [#34652]: https://github.com/JuliaLang/julia/issues/34652
 [#34773]: https://github.com/JuliaLang/julia/issues/34773

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -298,4 +298,14 @@ end
     @test evalpoly(1+im, [2,]) == 2
 end
 
+# https://github.com/JuliaLang/julia/pull/34548
+@testset "@NamedTuple" begin
+    @test (@NamedTuple {a::Int, b::String}) === NamedTuple{(:a, :b),Tuple{Int,String}} ===
+        @NamedTuple begin
+            a::Int
+            b::String
+        end
+    @test (@NamedTuple {a::Int, b}) === NamedTuple{(:a, :b),Tuple{Int,Any}}
+end
+
 nothing


### PR DESCRIPTION
Note cannot do
`@NamedTuple{a::Int, b::String}` since that's unavailable syntax for earlier version, but can still do 
`@NamedTuple {a::Int, b::String}`