### PR TITLE
Add mergewith[!](combine, dicts...)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.8.0"
+version = "3.9.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.9.0"
+version = "3.9.0-DEV"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `mergewith(combine, dicts...)` and `mergewith!(combine, dicts...)` are like
+  `merge(combine, dicts...)` and `merge!(combine, dicts...)` but without the restriction
+  that the argument `combine` must be a `Function` ([#34296]). (since Compat 3.9.0).
+
 * `@NamedTuple` macro for convenient `struct`-like syntax for declaring
 `NamedTuple` types via `key::Type` declarations ([#34548]). (since Compat 3.8.0)
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#34548]: https://github.com/JuliaLang/julia/pull/34548
 [#34652]: https://github.com/JuliaLang/julia/issues/34652
 [#34773]: https://github.com/JuliaLang/julia/issues/34773
+[#34296]: https://github.com/JuliaLang/julia/pull/34296

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -345,6 +345,18 @@ if VERSION < v"1.5.0-DEV.314"
     export @NamedTuple
 end
 
+_asfunction(f::Function) = f
+_asfunction(f) = (args...) -> f(args...)
+
+# https://github.com/JuliaLang/julia/pull/34296
+if VERSION < v"1.5.0-DEV.182"
+    export mergewith, mergewith!
+    mergewith(f, dicts...) = merge(_asfunction(f), dicts...)
+    mergewith!(f, dicts...) = merge!(_asfunction(f), dicts...)
+    mergewith(f) = (dicts...) -> mergewith(f, dicts...)
+    mergewith!(f) = (dicts...) -> mergewith!(f, dicts...)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -345,12 +345,11 @@ if VERSION < v"1.5.0-DEV.314"
     export @NamedTuple
 end
 
-_asfunction(f::Function) = f
-_asfunction(f) = (args...) -> f(args...)
-
 # https://github.com/JuliaLang/julia/pull/34296
 if VERSION < v"1.5.0-DEV.182"
     export mergewith, mergewith!
+    _asfunction(f::Function) = f
+    _asfunction(f) = (args...) -> f(args...)
     mergewith(f, dicts...) = merge(_asfunction(f), dicts...)
     mergewith!(f, dicts...) = merge!(_asfunction(f), dicts...)
     mergewith(f) = (dicts...) -> mergewith(f, dicts...)


### PR DESCRIPTION
Quoting README:

> * `mergewith(combine, dicts...)` and `mergewith!(combine, dicts...)` are like `merge(combine, dicts...)` and `merge!(combine, dicts...)` but without the restriction that the argument `combine` must be a `Function` ([#34296]). (since Compat 3.9.0).

Ref: https://github.com/JuliaLang/julia/pull/34296
