### PR TITLE
add isdisjoint (https://github.com/JuliaLang/julia/pull/34427/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
-* `isdisjoint(l, r)` indicates whether two collections are disjoint ([#34427]). (since Compat 3.8.0)
+* `isdisjoint(l, r)` indicates whether two collections are disjoint ([#34427]). (since Compat 3.9.0)
 
 * `@NamedTuple` macro for convenient `struct`-like syntax for declaring
 `NamedTuple` types via `key::Type` declarations ([#34548]). (since Compat 3.8.0)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Please check the list below for the specific syntax you need.
 
 ## Supported features
 
+* `isdisjoint(l, r)` indicates whether two collections are disjoint ([#34427]). (since Compat 3.8.0)
+
 * `@NamedTuple` macro for convenient `struct`-like syntax for declaring
 `NamedTuple` types via `key::Type` declarations ([#34548]). (since Compat 3.8.0)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#33129]: https://github.com/JuliaLang/julia/issues/33129
 [#33568]: https://github.com/JuliaLang/julia/issues/33568
 [#33736]: https://github.com/JuliaLang/julia/issues/33736
-[#34548]: https://github.com/JuliaLang/julia/pull/34548
+[#34296]: https://github.com/JuliaLang/julia/issues/34296
+[#34427]: https://github.com/JuliaLang/julia/issues/34427
+[#34548]: https://github.com/JuliaLang/julia/issues/34548
 [#34652]: https://github.com/JuliaLang/julia/issues/34652
 [#34773]: https://github.com/JuliaLang/julia/issues/34773
-[#34296]: https://github.com/JuliaLang/julia/pull/34296

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -345,6 +345,36 @@ if VERSION < v"1.5.0-DEV.314"
     export @NamedTuple
 end
 
+# https://github.com/JuliaLang/julia/pull/32003
+if VERSION < v"1.4.0-DEV.29"
+    hasfastin(::Type) = false
+    hasfastin(::Union{Type{<:AbstractSet},Type{<:AbstractDict},Type{<:AbstractRange}}) = true
+    hasfastin(x) = hasfastin(typeof(x))
+else
+    const hasfastin = Base.hasfastin
+end
+
+# https://github.com/JuliaLang/julia/pull/34427
+if VERSION < v"1.5.0-DEV.124"
+    const FASTIN_SET_THRESHOLD = 70
+
+    function isdisjoint(l, r)
+        function _isdisjoint(l, r)
+            hasfastin(r) && return !any(in(r), l)
+            hasfastin(l) && return !any(in(l), r)
+            Base.haslength(r) && length(r) < FASTIN_SET_THRESHOLD &&
+            return !any(in(r), l)
+            return !any(in(Set(r)), l)
+        end
+        if Base.haslength(l) && Base.haslength(r) && length(r) < length(l)
+            return _isdisjoint(r, l)
+        end
+        _isdisjoint(l, r)
+    end
+
+    export isdisjoint
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -363,7 +363,7 @@ if VERSION < v"1.5.0-DEV.124"
             hasfastin(r) && return !any(in(r), l)
             hasfastin(l) && return !any(in(l), r)
             Base.haslength(r) && length(r) < FASTIN_SET_THRESHOLD &&
-            return !any(in(r), l)
+                return !any(in(r), l)
             return !any(in(Set(r)), l)
         end
         if Base.haslength(l) && Base.haslength(r) && length(r) < length(l)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,4 +308,25 @@ end
     @test (@NamedTuple {a::Int, b}) === NamedTuple{(:a, :b),Tuple{Int,Any}}
 end
 
+# https://github.com/JuliaLang/julia/pull/34427
+@testset "isdisjoint" begin
+    for S in (Set, BitSet, Vector)
+        for (l,r) in ((S([1,2]),     S([3,4])),
+                      (S([5,6,7,8]), S([7,8,9])),
+                      (S([1,2]),     S([3,4])),
+                      (S([5,6,7,8]), S([7,8,9])),
+                      (S([1,2,3]),   S()),
+                      (S(),          S()),
+                      (S(),          S([1,2,3])),
+                      (S([1,2,3]),   S([1])),
+                      (S([1,2,3]),   S([1,2])),
+                      (S([1,2,3]),   S([1,2,3])),
+                      (S([1,2,3]),   S([4])),
+                      (S([1,2,3]),   S([4,1])))
+            @test isdisjoint(l,l) == isempty(l)
+            @test isdisjoint(l,r) == isempty(intersect(l,r))
+        end
+    end
+end
+
 nothing


### PR DESCRIPTION
Code copied from https://github.com/JuliaLang/julia/blob/098ef24c7acb989cae2516ac18bff498e9a69554/base/abstractset.jl#L390

I also had to add `hasfastin` (added in https://github.com/JuliaLang/julia/pull/32003), which `isdisjoint` depends on. I wasn't sure what the protocol was for non-exported functions so I added a separate if statement for `hasfastin` that just aliases `Base.hasfastin` if `VERSION >= v"1.4.0-DEV.29"`.
