### PR TITLE
RFC: Note that non-released features are experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Please check the list below for the specific syntax you need.
 Features in the development versions of `julia` may be added and released in
 Compat.jl.  However, such features are considered experimental until the
 relevant Julia version is released.  These features can be changed or removed
-without incrementing the major version of Compat.jl.
+without incrementing the major version of Compat.jl if necessary to match
+changes in `julia`.
 
 ## Supported features
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please check the list below for the specific syntax you need.
 
 Features in the development versions of `julia` may be added and released in
 Compat.jl.  However, such features are considered experimental until the
-relevant Julia version is released.  These features can be changed or removed
+relevant `julia` version is released.  These features can be changed or removed
 without incrementing the major version of Compat.jl if necessary to match
 changes in `julia`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ the syntax on Julia `master`. However, in a few cases where this is not possible
 a slightly different syntax might be used.
 Please check the list below for the specific syntax you need.
 
+## Compatibility
+
+Features in the development versions of `julia` may be added and released in
+Compat.jl.  However, such features are considered experimental until the
+relevant Julia version is released.  These features can be changed or removed
+without incrementing the major version of Compat.jl.
+
 ## Supported features
 
 * `@inferred [AllowedType] f(x)` is defined ([#27516]). (since Compat 3.12.0)


### PR DESCRIPTION
Some features in the development versions of Julia have already been merged and released in Compat.jl.  However, there is a chance that some features in Julia may be retracted or changed before actually released.  If this happens, Compat.jl cannot re-backport the change/deletion while maintaining the backward compatibility.  To workaround such problems, how about documenting that the unreleased features are experimental?  It seems to be a good middleground solution that avoids unwanted major bumps while allowing feature preview and testing new features in the wild.
