### PR TITLE
Add curried comparisons for !=, >=, <=, >, <

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ changes in `julia`.
 
 ## Supported features
 
+* Curried comparisons `!=(x)`, `>=(x)`, `<=(x)`, `>(x)`, and `<(x)` are defined as, e.g.,
+  `!=(x) = y -> y != x` ([#30915]). (since Compat 3.14)
+
 * `strides` is defined for Adjoint and Transpose ([#35929]). (since Compat 3.14)
 
 * `Compat.get_num_threads()` adds the functionality of `LinearAlgebra.BLAS.get_num_threads()`, and has matching `Compat.set_num_threads(n)` ([#36360]). (since Compat 3.13.0)

--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#27516]: https://github.com/JuliaLang/julia/pull/27516
 [#36360]: https://github.com/JuliaLang/julia/pull/36360
 [#35929]: https://github.com/JuliaLang/julia/pull/35929
+[#30915]: https://github.com/JuliaLang/julia/pull/30915

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -585,6 +585,15 @@ else
     import LinearAlgebra.BLAS: set_num_threads, get_num_threads
 end
 
+# https://github.com/JuliaLang/julia/pull/30915
+if VERSION < v"1.2.0-DEV.257" # e7e726b3df1991e1306ef0c566d363c0a83b2dea
+    Base.:(!=)(x) = Base.Fix2(!=, x)
+    Base.:(>=)(x) = Base.Fix2(>=, x)
+    Base.:(<=)(x) = Base.Fix2(<=, x)
+    Base.:(>)(x) = Base.Fix2(>, x)
+    Base.:(<)(x) = Base.Fix2(<, x)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -526,4 +526,21 @@ end
     end
 end
 
+# https://github.com/JuliaLang/julia/pull/30915
+@testset "curried comparisons" begin
+    eql5 = (==)(5)
+    neq5 = (!=)(5)
+    gte5 = (>=)(5)
+    lte5 = (<=)(5)
+    gt5  = (>)(5)
+    lt5  = (<)(5)
+
+    @test eql5(5) && !eql5(0)
+    @test neq5(6) && !neq5(5)
+    @test gte5(5) && gte5(6)
+    @test lte5(5) && lte5(4)
+    @test gt5(6) && !gt5(5)
+    @test lt5(4) && !lt5(5)
+end
+
 nothing


### PR DESCRIPTION
This PR backports https://github.com/JuliaLang/julia/pull/30915 to Julia < 1.2.

This patch does not update `Project.toml` since it looks like 3.14 is not released yet.
