### PR TITLE
Create Compat.Iterators; add takewhile, dropwhile and map

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ changes in `julia`.
 
 ## Supported features
 
+* `Compat.Iterators.map` is added. It provides another syntax `Iterators.map(f, iterators...)`
+  for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map`  ([#34352]).
+  (since Compat 3.14)
+
+* `takewhle` and `dropwhile` are added in `Compat.Iterators` ([#33437]). (since Compat 3.14)
+
 * Curried comparisons `!=(x)`, `>=(x)`, `<=(x)`, `>(x)`, and `<(x)` are defined as, e.g.,
   `!=(x) = y -> y != x` ([#30915]). (since Compat 3.14)
 
@@ -184,3 +190,5 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#36360]: https://github.com/JuliaLang/julia/pull/36360
 [#35929]: https://github.com/JuliaLang/julia/pull/35929
 [#30915]: https://github.com/JuliaLang/julia/pull/30915
+[#33437]: https://github.com/JuliaLang/julia/pull/33437
+[#34352]: https://github.com/JuliaLang/julia/pull/34352

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ changes in `julia`.
 
 ## Supported features
 
+* Curried comparisons `!=(x)`, `>=(x)`, `<=(x)`, `>(x)`, and `<(x)` are defined as, e.g.,
+  `!=(x) = y -> y != x` ([#30915]). (since Compat 3.14)
+
 * `strides` is defined for Adjoint and Transpose ([#35929]). (since Compat 3.14)
 
 * `Compat.get_num_threads()` adds the functionality of `LinearAlgebra.BLAS.get_num_threads()`, and has matching `Compat.set_num_threads(n)` ([#36360]). (since Compat 3.13.0)

--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#27516]: https://github.com/JuliaLang/julia/pull/27516
 [#36360]: https://github.com/JuliaLang/julia/pull/36360
 [#35929]: https://github.com/JuliaLang/julia/pull/35929
+[#30915]: https://github.com/JuliaLang/julia/pull/30915

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -594,6 +594,7 @@ if VERSION < v"1.2.0-DEV.257" # e7e726b3df1991e1306ef0c566d363c0a83b2dea
     Base.:(<)(x) = Base.Fix2(<, x)
 end
 
+include("iterators.jl")
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -585,6 +585,15 @@ else
     import LinearAlgebra.BLAS: set_num_threads, get_num_threads
 end
 
+# https://github.com/JuliaLang/julia/pull/30915
+if VERSION < v"1.2.0-DEV.257" # e7e726b3df1991e1306ef0c566d363c0a83b2dea
+    Base.:(!=)(x) = Base.Fix2(!=, x)
+    Base.:(>=)(x) = Base.Fix2(>=, x)
+    Base.:(<=)(x) = Base.Fix2(<=, x)
+    Base.:(>)(x) = Base.Fix2(>, x)
+    Base.:(<)(x) = Base.Fix2(<, x)
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,4 +1,16 @@
 module CompatIterators
+# Defining this module with the name `CompatIterators` and define
+# `const Iterators = CompatIterators` at the end of this file so that
+#
+#     julia> using Compat.Iterators
+#
+#     julia> Iterators
+#     Base.Iterators
+#
+# works without conflict in identifiers.  Users still need to
+# explicitly import `Compat.Iterators` via `using Compat: Iterators`
+# to use, e.g., `Iterators.map` before Julia 1.6.  This is the case
+# with and without the `CompatIterators` hack.
 
 using Base:
     @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -7,10 +7,13 @@ module CompatIterators
 #     julia> Iterators
 #     Base.Iterators
 #
-# works without conflict in identifiers.  Users still need to
-# explicitly import `Compat.Iterators` via `using Compat: Iterators`
-# to use, e.g., `Iterators.map` before Julia 1.6.  This is the case
-# with and without the `CompatIterators` hack.
+#     julia> takewhile
+#     takewhile (generic function with 1 method)
+#
+# works without conflict in identifiers in all Julia versions.  Users
+# still need to explicitly import `Compat.Iterators` via `using
+# Compat: Iterators` to use, e.g., `Iterators.map` before Julia 1.6.
+# This is the case with and without the `CompatIterators` hack.
 
 using Base: SizeUnknown
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -12,19 +12,12 @@ module CompatIterators
 # to use, e.g., `Iterators.map` before Julia 1.6.  This is the case
 # with and without the `CompatIterators` hack.
 
-using Base:
-    @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
-    tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
-    IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange,
-    LinearIndices, (:), |, +, -, !==, !, <=, <, missing, any, @boundscheck, @inbounds
+using Base: SizeUnknown
 
-import .Base:
-    first, last,
-    isempty, length, size, axes, ndims,
-    eltype, IteratorSize, IteratorEltype,
-    haskey, keys, values, pairs,
-    getindex, setindex!, get, iterate,
-    popfirst!, isdone, peek
+# We normally use `Base.f(...) = ...` style for overloading.  However,
+# we use `import Base: f` style here to make synchronizing the code
+# with `Base` easier.
+import Base: IteratorEltype, IteratorSize, eltype, iterate
 
 # Import exported APIs
 for n in names(Base.Iterators)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -14,9 +14,6 @@ import .Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek
 
-const Iterators = @__MODULE__
-export Iterators
-
 # Import exported APIs
 for n in names(Base.Iterators)
     n === :Iterators && continue

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,0 +1,87 @@
+module CompatIterators
+
+using Base:
+    @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
+    tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
+    IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange,
+    LinearIndices, (:), |, +, -, !==, !, <=, <, missing, any, @boundscheck, @inbounds
+
+import .Base:
+    first, last,
+    isempty, length, size, axes, ndims,
+    eltype, IteratorSize, IteratorEltype,
+    haskey, keys, values, pairs,
+    getindex, setindex!, get, iterate,
+    popfirst!, isdone, peek
+
+const Iterators = @__MODULE__
+export Iterators
+
+# Import exported APIs
+for n in names(Base.Iterators)
+    n === :Iterators && continue
+    @eval begin
+        using Base.Iterators: $n
+        export $n
+    end
+end
+
+# Import unexported public APIs
+using Base.Iterators: filter
+
+# https://github.com/JuliaLang/julia/pull/33437
+if VERSION < v"1.4.0-DEV.291"  # 5f013d82f92026f7dfbe4234f283658beb1f8a2a
+    export takewhile, dropwhile
+
+    # takewhile
+    struct TakeWhile{I,P<:Function}
+        pred::P
+        xs::I
+    end
+
+    takewhile(pred,xs) = TakeWhile(pred,xs)
+
+    function iterate(ibl::TakeWhile, itr...)
+        y = iterate(ibl.xs,itr...)
+        y === nothing && return nothing
+        ibl.pred(y[1]) || return nothing
+        y
+    end
+
+    IteratorSize(::Type{<:TakeWhile}) = SizeUnknown()
+    eltype(::Type{TakeWhile{I,P}}) where {I,P} = eltype(I)
+    IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = IteratorEltype(I)
+
+    # dropwhile
+    struct DropWhile{I,P<:Function}
+        pred::P
+        xs::I
+    end
+
+    dropwhile(pred,itr) = DropWhile(pred,itr)
+
+    iterate(ibl::DropWhile,itr) = iterate(ibl.xs, itr)
+    function iterate(ibl::DropWhile)
+        y = iterate(ibl.xs)
+        while y !== nothing
+            ibl.pred(y[1]) || break
+            y = iterate(ibl.xs,y[2])
+        end
+        y
+    end
+
+    IteratorSize(::Type{<:DropWhile}) = SizeUnknown()
+    eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
+    IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
+end
+
+# https://github.com/JuliaLang/julia/pull/34352
+if VERSION < v"1.6.0-DEV.258"  # 1f8b44204fafb1caabc6a1cd6ca39458a550e2fc
+    map(f, args...) = Base.Generator(f, args...)
+else
+    using Base.Iterators: map
+end
+
+end  # module
+
+const Iterators = CompatIterators

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1,7 +1,7 @@
 module TestIterators
 
 using Compat.Iterators
-using Compat: Iterators
+using Compat: Compat, Iterators
 using Test
 
 # https://github.com/JuliaLang/julia/pull/33437
@@ -29,6 +29,12 @@ end
 @testset "Iterators.map" begin
     @test collect(Iterators.map(string, 1:3)::Base.Generator) == map(string, 1:3)
     @test collect(Iterators.map(tuple, 1:3, 4:6)::Base.Generator) == map(tuple, 1:3, 4:6)
+end
+
+@testset "Iterators.filter" begin
+    # `Iterators.filter` already existed in Julia 1.0.  We just make
+    # sure that it is available under `Compat.Iterators` namespace.
+    @test Compat.Iterators.filter === Base.Iterators.filter
 end
 
 end  # module

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1,0 +1,34 @@
+module TestIterators
+
+using Compat.Iterators
+using Compat: Iterators
+using Test
+
+# https://github.com/JuliaLang/julia/pull/33437
+@testset "takewhile" begin
+    @test collect(takewhile(<(4),1:10)) == [1,2,3]
+    @test collect(takewhile(<(4),Iterators.countfrom(1))) == [1,2,3]
+    @test collect(takewhile(<(4),5:10)) == []
+    @test collect(takewhile(_->true,5:10)) == 5:10
+    @test collect(takewhile(isodd,[1,1,2,3])) == [1,1]
+    @test collect(takewhile(<(2), takewhile(<(3), [1,1,2,3]))) == [1,1]
+end
+
+# https://github.com/JuliaLang/julia/pull/33437
+@testset "dropwhile" begin
+    @test collect(dropwhile(<(4), 1:10)) == 4:10
+    @test collect(dropwhile(<(4), 1:10)) isa Vector{Int}
+    @test isempty(dropwhile(<(4), []))
+    @test collect(dropwhile(_->false,1:3)) == 1:3
+    @test isempty(dropwhile(_->true, 1:3))
+    @test collect(dropwhile(isodd,[1,1,2,3])) == [2,3]
+    @test collect(dropwhile(iseven,dropwhile(isodd,[1,1,2,3]))) == [3]
+end
+
+# https://github.com/JuliaLang/julia/pull/34352
+@testset "Iterators.map" begin
+    @test collect(Iterators.map(string, 1:3)::Base.Generator) == map(string, 1:3)
+    @test collect(Iterators.map(tuple, 1:3, 4:6)::Base.Generator) == map(tuple, 1:3, 4:6)
+end
+
+end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -543,4 +543,6 @@ end
     @test lt5(4) && !lt5(5)
 end
 
+include("iterators.jl")
+
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -526,4 +526,21 @@ end
     end
 end
 
+# https://github.com/JuliaLang/julia/pull/30915
+@testset "curried comparisons" begin
+    eql5 = (==)(5)
+    neq5 = (!=)(5)
+    gte5 = (>=)(5)
+    lte5 = (<=)(5)
+    gt5  = (>)(5)
+    lt5  = (<)(5)
+
+    @test eql5(5) && !eql5(0)
+    @test neq5(6) && !neq5(5)
+    @test gte5(5) && gte5(6)
+    @test lte5(5) && lte5(4)
+    @test gt5(6) && !gt5(5)
+    @test lt5(4) && !lt5(5)
+end
+
 nothing


### PR DESCRIPTION
This PR:

* creates a submodule `Compat.Iterators`
* adds `takewhile` and `dropwhile` from https://github.com/JuliaLang/julia/pull/33437
* adds `Iterators.map` from https://github.com/JuliaLang/julia/pull/34352

I added a submodule `Compat.Iterators` as otherwise I don't think it's possible to provide `Iterators.map`.

This PR includes the patch #714 since I need this for the test.
