### PR TITLE
Add `contains`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.14.0"
+version = "3.15.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `contains(haystack, needle)` and its one argument partially applied form `contains(haystack)` have been added, it acts like `occursin(needle, haystack)` ([#35132]). (since Compat 3.15)
+
 * `Compat.Iterators.map` is added. It provides another syntax `Iterators.map(f, iterators...)`
   for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map`  ([#34352]).
   (since Compat 3.14)
@@ -192,3 +194,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#30915]: https://github.com/JuliaLang/julia/pull/30915
 [#33437]: https://github.com/JuliaLang/julia/pull/33437
 [#34352]: https://github.com/JuliaLang/julia/pull/34352
+[#35132]: https://github.com/JuliaLang/julia/pull/35132

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -594,6 +594,12 @@ if VERSION < v"1.2.0-DEV.257" # e7e726b3df1991e1306ef0c566d363c0a83b2dea
     Base.:(<)(x) = Base.Fix2(<, x)
 end
 
+# https://github.com/JuliaLang/julia/pull/35132
+if VERSION < v"1.5.0-DEV.639" # cc6e121386758dff6ba7911770e48dfd59520199
+    contains(haystack::AbstractString, needle) = occursin(needle, haystack)
+    contains(needle) = Base.Fix2(contains, needle)
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -596,6 +596,7 @@ end
 
 # https://github.com/JuliaLang/julia/pull/35132
 if VERSION < v"1.5.0-DEV.639" # cc6e121386758dff6ba7911770e48dfd59520199
+    export contains
     contains(haystack::AbstractString, needle) = occursin(needle, haystack)
     contains(needle) = Base.Fix2(contains, needle)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,11 @@ end
     @test lt5(4) && !lt5(5)
 end
 
+@testset "contains" begin
+    @test contains("foo", "o")
+    @test contains("o")("foo")
+end
+
 include("iterators.jl")
 
 nothing


### PR DESCRIPTION
- add `contains(haystack, needle)` and curried-verion `contains(needle)` from https://github.com/JuliaLang/julia/pull/35132