### PR TITLE
Add curried `endswith`, `startswith`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ changes in `julia`.
 
 * `contains(haystack, needle)` and its one argument partially applied form `contains(haystack)` have been added, it acts like `occursin(needle, haystack)` ([#35132]). (since Compat 3.15)
 
+* `startswith(x)` and `endswith(x)`, returning partially-applied versions of the functions, similar to existing methods like `isequal(x)` ([#35052]). (since Compat 3.15)
+
 * `Compat.Iterators.map` is added. It provides another syntax `Iterators.map(f, iterators...)`
   for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map`  ([#34352]).
   (since Compat 3.14)
@@ -131,7 +133,6 @@ changes in `julia`.
 
 * `range` supporting `stop` as positional argument ([#28708]). (since Compat 1.3.0)
 
-
 ## Developer tips
 
 One of the most important rules for `Compat.jl` is to avoid breaking user code
@@ -195,3 +196,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#33437]: https://github.com/JuliaLang/julia/pull/33437
 [#34352]: https://github.com/JuliaLang/julia/pull/34352
 [#35132]: https://github.com/JuliaLang/julia/pull/35132
+[#35052]: https://github.com/JuliaLang/julia/pull/35052

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -601,6 +601,12 @@ if VERSION < v"1.5.0-DEV.639" # cc6e121386758dff6ba7911770e48dfd59520199
     contains(needle) = Base.Fix2(contains, needle)
 end
 
+# https://github.com/JuliaLang/julia/pull/35052
+if VERSION < v"1.5.0-DEV.438" # 0a43c0f1d21ce9c647c49111d93927369cd20f85
+    Base.endswith(s) = Base.Fix2(endswith, s)
+    Base.startswith(s) = Base.Fix2(startswith, s)
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -550,6 +550,12 @@ end
     @test contains("o")("foo")
 end
 
+# https://github.com/JuliaLang/julia/pull/35052
+@testset "curried startswith/endswith" begin
+    @test startswith("a")("abcd")
+    @test endswith("d")("abcd")
+end
+
 include("iterators.jl")
 
 nothing


### PR DESCRIPTION
- Add curried versions of `endswith` and `startswith` as per https://github.com/JuliaLang/julia/pull/35052/files
- edit: bumps version to 3.16, assuming 3.15 will be https://github.com/JuliaLang/Compat.jl/pull/718 (or i can rebase once that's merged if we want it to be one release)