### PR TITLE
Backport ComposedFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.16.0"
+version = "3.17.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ changes in `julia`.
 
 * `contains(haystack, needle)` and its one argument partially applied form `contains(haystack)` have been added, it acts like `occursin(needle, haystack)` ([#35132]). (since Compat 3.15)
 
+* `startswith(x)` and `endswith(x)`, returning partially-applied versions of the functions, similar to existing methods like `isequal(x)` ([#35052]). (since Compat 3.15)
+
 * `Compat.Iterators.map` is added. It provides another syntax `Iterators.map(f, iterators...)`
   for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map`  ([#34352]).
   (since Compat 3.14)
@@ -131,7 +133,6 @@ changes in `julia`.
 
 * `range` supporting `stop` as positional argument ([#28708]). (since Compat 1.3.0)
 
-
 ## Developer tips
 
 One of the most important rules for `Compat.jl` is to avoid breaking user code
@@ -195,3 +196,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#33437]: https://github.com/JuliaLang/julia/pull/33437
 [#34352]: https://github.com/JuliaLang/julia/pull/34352
 [#35132]: https://github.com/JuliaLang/julia/pull/35132
+[#35052]: https://github.com/JuliaLang/julia/pull/35052

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ changes in `julia`.
 
 ## Supported features
 
+* The composition operator `∘` now returns a `Compat.ComposedFunction` instead of an anonymous function ([#37517]). (since Compat 3.17)
+
 * New function `addenv` for adding environment mappings into a `Cmd` object, returning the new `Cmd` object ([#37244]). (since Compat 3.16)
 
 * `contains(haystack, needle)` and its one argument partially applied form `contains(haystack)` have been added, it acts like `occursin(needle, haystack)` ([#35132]). (since Compat 3.15)
@@ -200,3 +202,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#35132]: https://github.com/JuliaLang/julia/pull/35132
 [#35052]: https://github.com/JuliaLang/julia/pull/35052
 [#37244]: https://github.com/JuliaLang/julia/pull/37244
+[#37517]: https://github.com/JuliaLang/julia/pull/37517

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -614,6 +614,9 @@ if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is
         const ComposedFunction = let h = identity ∘ convert
             Base.typename(typeof(h)).wrapper
         end
+        @eval ComposedFunction{F,G}(f, g) where {F,G} =
+            $(Expr(:new, :(ComposedFunction{F,G}), :f, :g))
+        ComposedFunction(f::F, g::G) where {F,G} = ComposedFunction{F,G}(f, g)
     else
         using Base: ComposedFunction
     end

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -608,7 +608,7 @@ if VERSION < v"1.5.0-DEV.438" # 0a43c0f1d21ce9c647c49111d93927369cd20f85
 end
 
 # https://github.com/JuliaLang/julia/pull/37517
-if VERSION < v"1.6.0" # TODO: specify the version when JuliaLang/julia#37517 is merged
+if VERSION < v"1.6.0-DEV.1037"
     export ComposedFunction
     # https://github.com/JuliaLang/julia/pull/35980
     if VERSION < v"1.6.0-DEV.85"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -608,7 +608,7 @@ if VERSION < v"1.5.0-DEV.438" # 0a43c0f1d21ce9c647c49111d93927369cd20f85
 end
 
 # https://github.com/JuliaLang/julia/pull/37517
-if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is merged
+if VERSION < v"1.6.0" # TODO: specify the version when JuliaLang/julia#37517 is merged
     # https://github.com/JuliaLang/julia/pull/35980
     if VERSION < v"1.6.0-DEV.85"
         const ComposedFunction = let h = identity ∘ convert

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -609,6 +609,7 @@ end
 
 # https://github.com/JuliaLang/julia/pull/37517
 if VERSION < v"1.6.0" # TODO: specify the version when JuliaLang/julia#37517 is merged
+    export ComposedFunction
     # https://github.com/JuliaLang/julia/pull/35980
     if VERSION < v"1.6.0-DEV.85"
         const ComposedFunction = let h = identity ∘ convert

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -612,7 +612,7 @@ if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is
     # https://github.com/JuliaLang/julia/pull/35980
     if VERSION < v"1.6.0-DEV.85"
         const ComposedFunction = let h = identity ∘ convert
-            getfield(parentmodule(typeof(h)), nameof(typeof(h)))
+            Base.typename(typeof(h)).wrapper
         end
     else
         using Base: ComposedFunction

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -601,6 +601,12 @@ if VERSION < v"1.5.0-DEV.639" # cc6e121386758dff6ba7911770e48dfd59520199
     contains(needle) = Base.Fix2(contains, needle)
 end
 
+# https://github.com/JuliaLang/julia/pull/35052
+if VERSION < v"1.5.0-DEV.438" # 0a43c0f1d21ce9c647c49111d93927369cd20f85
+    Base.endswith(s) = Base.Fix2(endswith, s)
+    Base.startswith(s) = Base.Fix2(startswith, s)
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -607,6 +607,33 @@ if VERSION < v"1.5.0-DEV.438" # 0a43c0f1d21ce9c647c49111d93927369cd20f85
     Base.startswith(s) = Base.Fix2(startswith, s)
 end
 
+# https://github.com/JuliaLang/julia/pull/37517
+if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is merged
+    # https://github.com/JuliaLang/julia/pull/35980
+    if VERSION < v"1.6.0-DEV.85"
+        const ComposedFunction = let h = identity ∘ convert
+            getfield(parentmodule(typeof(h)), nameof(typeof(h)))
+        end
+    else
+        using Base: ComposedFunction
+    end
+    function Base.getproperty(c::ComposedFunction, p::Symbol)
+        if p === :f
+            return getfield(c, :f)
+        elseif p === :g
+            return getfield(c, :g)
+        elseif p === :outer
+            return getfield(c, :f)
+        elseif p === :inner
+            return getfield(c, :g)
+        end
+        error("type ComposedFunction has no property ", p)
+    end
+    Base.propertynames(c::ComposedFunction) = (:f, :g, :outer, :inner)
+else
+    using Base: ComposedFunction
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,7 +563,7 @@ end
     c = sin ∘ cos
     @test c.outer === sin
     @test c.inner === cos
-    if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is merged
+    if VERSION < v"1.6.0" # TODO: specify the version when JuliaLang/julia#37517 is merged
         @test c.f === sin
         @test c.g === cos
         @test propertynames(c) == (:f, :g, :outer, :inner)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -556,6 +556,21 @@ end
     @test endswith("d")("abcd")
 end
 
+# https://github.com/JuliaLang/julia/pull/37517
+@testset "ComposedFunction" begin
+    @test sin ∘ cos isa Compat.ComposedFunction
+    c = sin ∘ cos
+    @test c.outer === sin
+    @test c.inner === cos
+    if VERSION < v"1.6.0-" # TODO: specify the version when JuliaLang/julia#37517 is merged
+        @test c.f === sin
+        @test c.g === cos
+        @test propertynames(c) == (:f, :g, :outer, :inner)
+    else
+        @test propertynames(c) == (:outer, :inner)
+    end
+end
+
 include("iterators.jl")
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -550,6 +550,12 @@ end
     @test contains("o")("foo")
 end
 
+# https://github.com/JuliaLang/julia/pull/35052
+@testset "curried startswith/endswith" begin
+    @test startswith("a")("abcd")
+    @test endswith("d")("abcd")
+end
+
 include("iterators.jl")
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,7 +563,7 @@ end
     c = sin ∘ cos
     @test c.outer === sin
     @test c.inner === cos
-    if VERSION < v"1.6.0" # TODO: specify the version when JuliaLang/julia#37517 is merged
+    if VERSION < v"1.6.0-DEV.1037"
         @test c.f === sin
         @test c.g === cos
         @test propertynames(c) == (:f, :g, :outer, :inner)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -559,6 +559,7 @@ end
 # https://github.com/JuliaLang/julia/pull/37517
 @testset "ComposedFunction" begin
     @test sin ∘ cos isa Compat.ComposedFunction
+    @test sin ∘ cos === Compat.ComposedFunction(sin, cos)
     c = sin ∘ cos
     @test c.outer === sin
     @test c.inner === cos


### PR DESCRIPTION
I suggest adding `Compat.ComposedFunction` when/if https://github.com/JuliaLang/julia/pull/37517 is merged. This way, individual packages like DataFrames.jl don't have to implement the same hack.

* [x] Wait for https://github.com/JuliaLang/julia/pull/37517
* [x] Add changelog in README
* [x] Bump version
