### PR TITLE
Add `sincospi(x)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.22.0"
+version = "3.23.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `sincospi(x)` for calculating the tuple `(sinpi(x), cospi(x))` ([#35816]) (since Compat 3.23)
+
 * `Dates.canonicalize` can now take a `Period` as an input ([#37391]) (since Compat 3.22)
 
 * Import renaming is available through the `@compat` macro, e.g. `@compat import LinearAlgebra as LA` and
@@ -227,3 +229,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#35243]: https://github.com/JuliaLang/julia/pull/35243
 [#37396]: https://github.com/JuliaLang/julia/pull/37396
 [#37391]: https://github.com/JuliaLang/julia/pull/37391
+[#35816]: https://github.com/JuliaLang/julia/pull/35816

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -814,6 +814,12 @@ if VERSION < v"1.6.0-DEV.820"
     Dates.canonicalize(p::Period) = Dates.canonicalize(CompoundPeriod(p))
 end
 
+# https://github.com/JuliaLang/julia/pull/35816
+if VERSION < v"1.6.0-DEV.292" # 6cd329c371c1db3d9876bc337e82e274e50420e8
+    export sincospi
+    sincospi(x) = (sinpi(x), cospi(x))
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -765,6 +765,15 @@ end
     @test Dates.canonicalize(Dates.Minute(24*60*1 + 12*60)) == Dates.canonicalize(Dates.CompoundPeriod([Dates.Day(1),Dates.Hour(12)]))
 end
 
+# https://github.com/JuliaLang/julia/pull/35816
+@testset "sincospi(x)" begin
+    @test sincospi(0.13) == (sinpi(0.13), cospi(0.13))
+    @test sincospi(1//3) == (sinpi(1//3), cospi(1//3))
+    @test sincospi(5) == (sinpi(5), cospi(5))
+    @test sincospi(ℯ) == (sinpi(ℯ), cospi(ℯ))
+    @test sincospi(0.13im) == (sinpi(0.13im), cospi(0.13im))
+end
+
 include("iterators.jl")
 
 # Import renaming, https://github.com/JuliaLang/julia/pull/37396,


### PR DESCRIPTION
Added to Base in JuliaLang/julia#35816

The five tests I added cover the methods I see on Julia v1.6 master:
```julia
julia> methods(sincospi)
# 5 methods for generic function "sincospi":
[1] sincospi(x::T) where T<:AbstractFloat in Base.Math at special/trig.jl:871
[2] sincospi(x::T) where T<:Rational in Base.Math at special/trig.jl:903
[3] sincospi(x::Integer) in Base.Math at special/trig.jl:935
[4] sincospi(x::Real) in Base.Math at special/trig.jl:938
[5] sincospi(z::Complex{T}) where T in Base.Math at special/trig.jl:1009
```