### PR TITLE
tryparse VersionNumber

### DIFF
--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -820,6 +820,27 @@ if VERSION < v"1.6.0-DEV.292" # 6cd329c371c1db3d9876bc337e82e274e50420e8
     sincospi(x) = (sinpi(x), cospi(x))
 end
 
+# https://github.com/JuliaLang/julia/pull/37803
+if VERSION < v"1.5.3"
+    function Base.tryparse(::Type{VersionNumber}, v::AbstractString)
+        VerTuple = Tuple{Vararg{Union{UInt64,String}}}
+
+        v == "∞" && return typemax(VersionNumber)
+        m = match(Base.VERSION_REGEX, v)
+        m === nothing && return nothing
+        major, minor, patch, minus, prerl, plus, build = m.captures
+        major = parse(Base.VInt, major)
+        minor = minor !== nothing ? parse(Base.VInt, minor) : Base.VInt(0)
+        patch = patch !== nothing ? parse(Base.VInt, patch) : Base.VInt(0)
+        if prerl !== nothing && !isempty(prerl) && prerl[1] == '-'
+            prerl = prerl[2:end] # strip leading '-'
+        end
+        prerl = prerl !== nothing ? split_idents(prerl) : minus !== nothing ? ("",) : ()
+        build = build !== nothing ? split_idents(build) : plus  !== nothing ? ("",) : ()
+        return VersionNumber(major, minor, patch, prerl::VerTuple, build::VerTuple)
+    end
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -821,7 +821,7 @@ if VERSION < v"1.6.0-DEV.292" # 6cd329c371c1db3d9876bc337e82e274e50420e8
 end
 
 # https://github.com/JuliaLang/julia/pull/37803
-if VERSION < v"1.5.3"
+if VERSION < v"1.6.0-DEV.1090"
     function Base.tryparse(::Type{VersionNumber}, v::AbstractString)
         VerTuple = Tuple{Vararg{Union{UInt64,String}}}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -774,6 +774,18 @@ end
     @test sincospi(0.13im) == (sinpi(0.13im), cospi(0.13im))
 end
 
+@testset "tryparse(::VersionNumber, ::AbstractString)" begin
+    @test tryparse(VersionNumber, "v1.2.3") == v"1.2.3"
+    @test tryparse(VersionNumber, "v1.2") == v"1.2.0"
+    @test tryparse(VersionNumber, "v1") == v"1.0.0"
+    @test tryparse(VersionNumber, "v0.1") == v"0.1.0"
+    @test tryparse(VersionNumber, "v0.0.1") == v"0.0.1"
+    @test tryparse(VersionNumber, "∞") == v"∞"
+    @test tryparse(VersionNumber, "") === nothing
+    @test tryparse(VersionNumber, "foobar") === nothing
+    @test tryparse(VersionNumber, "v0.0.0.1") === nothing
+end
+
 include("iterators.jl")
 
 # Import renaming, https://github.com/JuliaLang/julia/pull/37396,


### PR DESCRIPTION
Looking to add in the [tryparse](https://github.com/JuliaLang/julia/blob/master/base/version.jl#L108) functionality from `master` here.

I'm not sure the proper procedure for requesting changes here but I've tested this functionality locally with Julia `1.0.5, 1.3.0, 1.5.0` and it checks out. ~~I'm also a bit unsure if I used the proper version in `if VERSION < v"X.Y.Z"`, as I was unable to find any of the `DEV` releases.~~