### PR TITLE
Add `cispi(x)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.24.0"
+version = "3.25.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ without incrementing the major version of Compat.jl if necessary to match
 changes in `julia`.
 
 ## Supported features
+
+* `cispi(x)` for accurately calculating `cis(pi * x)` ([#38449]) (since Compat 3.25)
+
 * `startswith(s, r::Regex)` and `endswith(s, r::Regex)` ([#29790]) (since Compat 3.24)
 
 * `sincospi(x)` for calculating the tuple `(sinpi(x), cospi(x))` ([#35816]) (since Compat 3.23)
@@ -232,3 +235,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#37391]: https://github.com/JuliaLang/julia/pull/37391
 [#35816]: https://github.com/JuliaLang/julia/pull/35816
 [#29790]: https://github.com/JuliaLang/julia/pull/29790
+[#38449]: https://github.com/JuliaLang/julia/pull/38449

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -820,6 +820,16 @@ if VERSION < v"1.6.0-DEV.292" # 6cd329c371c1db3d9876bc337e82e274e50420e8
     sincospi(x) = (sinpi(x), cospi(x))
 end
 
+# https://github.com/JuliaLang/julia/pull/38449
+if VERSION < v"1.6.0-DEV.1591" # 96d59f957e4c0413e2876592072c0f08a7482cf2
+    export cispi
+    cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
+    function cispi(z::Complex)
+        sipi, copi = sincospi(z)
+        return complex(real(copi) - imag(sipi), imag(copi) + real(sipi))
+    end
+end
+
 # https://github.com/JuliaLang/julia/pull/29790
 if VERSION < v"1.2.0-DEV.246"
     using Base.PCRE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -774,6 +774,14 @@ end
     @test sincospi(0.13im) == (sinpi(0.13im), cospi(0.13im))
 end
 
+# https://github.com/JuliaLang/julia/pull/38449
+@testset "cispi(x)" begin
+    @test cispi(true) == -1 + 0im
+    @test cispi(1)    == -1.0 + 0.0im
+    @test cispi(2.0)  == 1.0 + 0.0im
+    @test cispi(0.25 + 1im) ≈ cis(π/4 + π*im)
+end
+
 include("iterators.jl")
 
 # Import renaming, https://github.com/JuliaLang/julia/pull/37396,


### PR DESCRIPTION
Added to Base in JuliaLang/julia#38449

I added tests that cover both methods in Base:
```julia
julia> methods(cispi)
[1] cispi(theta::Real) in Base at complex.jl:544
[2] cispi(z::Complex) in Base at complex.jl:563
```
(both of the doc tests and then a couple more examples of real inputs).