### PR TITLE
`startswith` and `endswith` that work with `Regex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.23.0"
+version = "3.24.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ without incrementing the major version of Compat.jl if necessary to match
 changes in `julia`.
 
 ## Supported features
-* `startswith(s, r)`, and `endswith(s, r)` where `r` is a `regex` ([#29790]) (since Compat 3.24)
+* `startswith(s, r::Regex)` and `endswith(s, r::Regex)` ([#29790]) (since Compat 3.24)
 
 * `sincospi(x)` for calculating the tuple `(sinpi(x), cospi(x))` ([#35816]) (since Compat 3.23)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ without incrementing the major version of Compat.jl if necessary to match
 changes in `julia`.
 
 ## Supported features
+* `startswith(s, r)`, and `endswith(s, r)` where `r` is a `regex` ([#29790]) (since Compat 3.24)
 
 * `sincospi(x)` for calculating the tuple `(sinpi(x), cospi(x))` ([#35816]) (since Compat 3.23)
 
@@ -230,3 +231,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#37396]: https://github.com/JuliaLang/julia/pull/37396
 [#37391]: https://github.com/JuliaLang/julia/pull/37391
 [#35816]: https://github.com/JuliaLang/julia/pull/35816
+[#29790]: https://github.com/JuliaLang/julia/pull/29790

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -820,6 +820,35 @@ if VERSION < v"1.6.0-DEV.292" # 6cd329c371c1db3d9876bc337e82e274e50420e8
     sincospi(x) = (sinpi(x), cospi(x))
 end
 
+# https://github.com/JuliaLang/julia/pull/29790
+if VERSION < v"1.2.0-DEV.246"
+    using Base.PCRE
+
+    function Base.startswith(s::AbstractString, r::Regex)
+        Base.compile(r)
+        return PCRE.exec(
+            r.regex, String(s), 0, r.match_options | PCRE.ANCHORED, r.match_data
+        )
+    end
+
+    function Base.startswith(s::SubString, r::Regex)
+        Base.compile(r)
+        return PCRE.exec(r.regex, s, 0, r.match_options | PCRE.ANCHORED, r.match_data)
+    end
+
+    function Base.endswith(s::AbstractString, r::Regex)
+        Base.compile(r)
+        return PCRE.exec(
+            r.regex, String(s), 0, r.match_options | PCRE.ENDANCHORED, r.match_data
+        )
+    end
+
+    function Base.endswith(s::SubString, r::Regex)
+        Base.compile(r)
+        return PCRE.exec(r.regex, s, 0, r.match_options | PCRE.ENDANCHORED, r.match_data)
+    end
+end
+
 include("iterators.jl")
 include("deprecated.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -802,3 +802,18 @@ import LinearAlgebra
     @test ImportRename.hm === LinearAlgebra.BLAS.hemm
     @test !isdefined(ImportRename, :hemm)
 end
+
+# https://github.com/JuliaLang/julia/pull/29790
+@testset "regex startswith and endswith" begin
+    @test startswith("abc", r"a")
+    @test endswith("abc", r"c")
+    @test !startswith("abc", r"b")
+    @test !startswith("abc", r"c")
+    @test !endswith("abc", r"a")
+    @test !endswith("abc", r"b")
+
+    @test !startswith("abc", r"A")
+    @test startswith("abc", r"A"i)
+    @test !endswith("abc", r"C")
+    @test endswith("abc", r"C"i)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -806,14 +806,22 @@ end
 # https://github.com/JuliaLang/julia/pull/29790
 @testset "regex startswith and endswith" begin
     @test startswith("abc", r"a")
+    @test startswith("abc", r"ab")
     @test endswith("abc", r"c")
+    @test endswith("abc", r"bc")
     @test !startswith("abc", r"b")
     @test !startswith("abc", r"c")
+    @test !startswith("abc", r"bc")
     @test !endswith("abc", r"a")
     @test !endswith("abc", r"b")
+    @test !endswith("abc", r"ab")
 
     @test !startswith("abc", r"A")
+    @test !startswith("abc", r"aB")
     @test startswith("abc", r"A"i)
+    @test startswith("abc", r"aB"i)
     @test !endswith("abc", r"C")
+    @test !endswith("abc", r"Bc")
     @test endswith("abc", r"C"i)
+    @test endswith("abc", r"Bc"i)
 end


### PR DESCRIPTION
Implements `startswith(s,r)` and `endswith(s,r)` where `r` is a `Regex`

https://github.com/JuliaLang/julia/pull/29790