### PR TITLE
Run CI against Julia 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,13 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.0
-          - 1.1
-          - 1.2
-          - 1.3
-          - 1.4
-          - 1.5
-          - 1.6
+          - "1.0"
+          - "1.1"
+          - "1.2"
+          - "1.3"
+          - "1.4"
+          - "1.5"
+          - "1.6"
           - nightly
         os:
           - ubuntu-latest


### PR DESCRIPTION
Using `1.0` in YAML gets automatically converted to `1` which results in the latest version of Julia 1 being run and not the latest version of 1.0. I quoted the other Julia version numbers just to be consistent. 

Introduced in #739