### PR TITLE
Port implicit named tuple and keyword argument names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.31.1"
+version = "3.32.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ changes in `julia`.
 
 ## Supported features
 
-* Implicit keywords arguments or named tuples is supported using the `@compat` macro, e.g. `@compat f(; x, f.p)` and `@compat (; x, f.p)` is equivalent to `f(; x=x, p=f.p)` and `(; x=x, f.p)` respectively. ([#34331]) (since Compat 3.32.0)
+* Implicit keywords arguments or named tuples is supported using the `@compat` macro, e.g. `@compat f(; x, f.p)` and `@compat (; x, f.p)` is equivalent to `f(; x=x, p=f.p)` and `(; x=x, p=f.p)` respectively. ([#34331]) (since Compat 3.32.0)
 
 * Two argument methods `findmax(f, domain)`, `argmax(f, domain)` and the corresponding `min` versions ([#35316], [#41076]) (since Compat 3.31.1)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ changes in `julia`.
 
 ## Supported features
 
-* Implicit keywords arguments or named tuples is supported using the `@compat` macro, e.g. `@compat f(; x, f.p)` and `@compat (; x, f.p)` is equivalent to `f(; x=x, p=f.p)` and `(; x=x, f.p)` respectively. ([#34331])
+* Implicit keywords arguments or named tuples is supported using the `@compat` macro, e.g. `@compat f(; x, f.p)` and `@compat (; x, f.p)` is equivalent to `f(; x=x, p=f.p)` and `(; x=x, f.p)` respectively. ([#34331]) (since Compat 3.32.0)
 
 * Two argument methods `findmax(f, domain)`, `argmax(f, domain)` and the corresponding `min` versions ([#35316], [#41076]) (since Compat 3.31.1)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ changes in `julia`.
 
 ## Supported features
 
+* Implicit keywords arguments or named tuples is supported using the `@compat` macro, e.g. `@compat f(; x, f.p)` and `@compat (; x, f.p)` is equivalent to `f(; x=x, p=f.p)` and `(; x=x, f.p)` respectively. ([#34331])
+
 * Two argument methods `findmax(f, domain)`, `argmax(f, domain)` and the corresponding `min` versions ([#35316], [#41076]) (since Compat 3.31.1)
 
 * `isunordered(x)` returns true if `x` is value that is normally unordered, such as `NaN` or `missing` ([#35316]) (since Compat 3.31.1)
@@ -258,3 +260,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#41032]: https://github.com/JuliaLang/julia/pull/41032
 [#35316]: https://github.com/JuliaLang/julia/pull/35316
 [#41076]: https://github.com/JuliaLang/julia/pull/41076
+[#34331]: https://github.com/JuliaLang/julia/pull/34331

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1068,3 +1068,22 @@ end
          @test get(() -> c[]+=1, x, (3,2,1)) == 3
     end
 end
+
+# https://github.com/JuliaLang/julia/pull/34331
+struct X
+    x
+end
+
+@testset "implicit keywords" begin
+    f(; x=0) = x
+    x = 1
+    s = X(2)
+    nested = X(X(3))
+
+    @test (@compat f(; x)) == 1
+    @test (@compat f(; s.x)) == 2
+    @test (@compat f(; nested.x.x)) == 3
+    @test (@compat (; x)) == (; x=1)
+    @test (@compat (; s.x)) == (; x=2)
+    @test (@compat (; nested.x.x)) == (; x=3)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Compat.jl/issues/699. I implemented this without noticing that issue so this implementation was created independently from the mentioned package