### PR TITLE
Test against Julia 1.7 on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
           - "1.4"
           - "1.5"
           - "1.6"
+          - "1.7"
           - nightly
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
           - "1.4"
           - "1.5"
           - "1.6"
-          - "1.7"
+          - "~1.7.0-0"
           - nightly
         os:
           - ubuntu-latest


### PR DESCRIPTION
Now that "nightly" runs Julia 1.8 we should test against Julia 1.7 which is currently RC1