### PR TITLE
Add support for Base.display_error over ExceptionStack.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.38.0"
+version = "3.39.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1156,6 +1156,17 @@ if VERSION < v"1.7.0-DEV.1106"
         end
     end
 
+    if VERSION >= v"1.2"
+        # Base.scrub_repl_backtrace only exists as of Julia 1.2,
+        # hence the immediately preceding version guard.
+        function Base.display_error(io::IO, stack::ExceptionStack)
+            printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
+            bt = Any[ (x[1], Base.scrub_repl_backtrace(x[2])) for x in stack ]
+            show_exception_stack(IOContext(io, :limit => true), bt)
+            println(io)
+        end
+    end
+
     function Base.show(io::IO, ::MIME"text/plain", stack::ExceptionStack)
         nexc = length(stack)
         printstyled(io, nexc, "-element ExceptionStack", nexc == 0 ? "" : ":\n")

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1156,15 +1156,14 @@ if VERSION < v"1.7.0-DEV.1106"
         end
     end
 
-    if VERSION >= v"1.2"
-        # Base.scrub_repl_backtrace only exists as of Julia 1.2,
-        # hence the immediately preceding version guard.
-        function Base.display_error(io::IO, stack::ExceptionStack)
-            printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
-            bt = Any[ (x[1], Base.scrub_repl_backtrace(x[2])) for x in stack ]
-            show_exception_stack(IOContext(io, :limit => true), bt)
-            println(io)
-        end
+    function Base.display_error(io::IO, stack::ExceptionStack)
+        printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
+        # Julia >=1.2 provides Base.scrub_repl_backtrace; we use it
+        # where possible and otherwise leave backtraces unscrubbed.
+        backtrace_scrubber = VERSION >= v"1.2" ? Base.scrub_repl_backtrace : identity
+        bt = Any[ (x[1], backtrace_scrubber(x[2])) for x in stack ]
+        show_exception_stack(IOContext(io, :limit => true), bt)
+        println(io)
     end
 
     function Base.show(io::IO, ::MIME"text/plain", stack::ExceptionStack)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1164,6 +1164,27 @@ end
 
         caused by: UndefVarError: __not_a_binding__ not defined"""s,
         sprint(show, excs_sans_bts))
+
+        if VERSION >= v"1.2"
+            # The tested implementation of Base.display_error is only available
+            # as of Julia 1.2, hence the immediately preceding version guard.
+            
+            # Check that the ExceptionStack with backtraces `display_error`s correctly:
+            @test occursin(r"""
+            ERROR: DivideError: integer division error
+            Stacktrace:.*
+
+            caused by: UndefVarError: __not_a_binding__ not defined
+            Stacktrace:.*
+            """s, sprint(Base.display_error, excs_with_bts))
+
+            # Check that the ExceptionStack without backtraces `display_error`s correctly:
+            @test occursin(r"""
+            ERROR: DivideError: integer division error
+
+            caused by: UndefVarError: __not_a_binding__ not defined"""s,
+            sprint(Base.display_error, excs_sans_bts))
+        end
     else
         # Due to runtime limitations, julia-1.0 only retains the last exception.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1165,26 +1165,21 @@ end
         caused by: UndefVarError: __not_a_binding__ not defined"""s,
         sprint(show, excs_sans_bts))
 
-        if VERSION >= v"1.2"
-            # The tested implementation of Base.display_error is only available
-            # as of Julia 1.2, hence the immediately preceding version guard.
-            
-            # Check that the ExceptionStack with backtraces `display_error`s correctly:
-            @test occursin(r"""
-            ERROR: DivideError: integer division error
-            Stacktrace:.*
+        # Check that the ExceptionStack with backtraces `display_error`s correctly:
+        @test occursin(r"""
+        ERROR: DivideError: integer division error
+        Stacktrace:.*
 
-            caused by: UndefVarError: __not_a_binding__ not defined
-            Stacktrace:.*
-            """s, sprint(Base.display_error, excs_with_bts))
+        caused by: UndefVarError: __not_a_binding__ not defined
+        Stacktrace:.*
+        """s, sprint(Base.display_error, excs_with_bts))
 
-            # Check that the ExceptionStack without backtraces `display_error`s correctly:
-            @test occursin(r"""
-            ERROR: DivideError: integer division error
+        # Check that the ExceptionStack without backtraces `display_error`s correctly:
+        @test occursin(r"""
+        ERROR: DivideError: integer division error
 
-            caused by: UndefVarError: __not_a_binding__ not defined"""s,
-            sprint(Base.display_error, excs_sans_bts))
-        end
+        caused by: UndefVarError: __not_a_binding__ not defined"""s,
+        sprint(Base.display_error, excs_sans_bts))
     else
         # Due to runtime limitations, julia-1.0 only retains the last exception.
 
@@ -1204,6 +1199,17 @@ end
         1-element ExceptionStack:
         DivideError: integer division error""",
         sprint(show, excs_sans_bts))
+
+        # Check that the ExceptionStack with backtraces `display_error`s correctly:
+        @test occursin(r"""
+        ERROR: DivideError: integer division error
+        Stacktrace:.*
+        """, sprint(Base.display_error, excs_with_bts))
+
+        # Check that the ExceptionStack without backtraces `display_error`s correctly:
+        @test occursin(r"""
+        ERROR: DivideError: integer division error""",
+        sprint(Base.display_error, excs_sans_bts))
     end
 end
 


### PR DESCRIPTION
https://github.com/JuliaLang/Compat.jl/pull/746 added support for `current_exceptions`/`ExceptionStack` (née `catch_stack`), and augmented a few functions with methods that commonly handle `ExceptionStack`s. This pull request extends that to support to `Base.display_error`, which also commonly handles `ExceptionStack`s. Best! :)