### PR TITLE
Add support for property destructuring in `@compat` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.42.0"
+version = "3.43.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `@compat (; a, b) = (; c=1, b=2, a=3)` supports property descturing assignment syntax ([#39285]).
+
 * `allequal`, the opposite of `allunique` ([#43354]). (since Compat 3.42.0)
 
 * `eachsplit` for iteratively performing split(str). ([#39245]). (since Compat 3.41.0)
@@ -293,3 +295,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#41312]: https://github.com/JuliaLang/julia/pull/41312
 [#41328]: https://github.com/JuliaLang/julia/pull/41328
 [#43354]: https://github.com/JuliaLang/julia/pull/43354
+[#39285]: https://github.com/JuliaLang/julia/pull/39285

--- a/src/compatmacro.jl
+++ b/src/compatmacro.jl
@@ -16,7 +16,8 @@ function _compat(ex::Expr)
         end
     end
 
-    @static if VERSION < v"1.7.0"
+    # https://github.com/JuliaLang/julia/pull/39285
+    @static if VERSION < v"1.7.0-DEV.364"
         ex = _destructure_named_tuple(ex)
     end
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1094,6 +1094,9 @@ end
     @compat (; c, b) = nt
     @test c == nt.c
     @test b == nt.b
+
+    @compat (; x) = X(1)
+    @test x == 1
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1088,6 +1088,15 @@ end
     @test (@compat (; nested.x.x)) == (; x=3)
 end
 
+# https://github.com/JuliaLang/julia/pull/39285
+@testset "property destructuring assignment" begin
+    nt = (; a=1, b=2, c=3)
+    @compat (; c, b) = nt
+    @test c == nt.c
+    @test b == nt.b
+end
+
+
 # https://github.com/JuliaLang/julia/pull/34595
 @testset "include(mapexpr::Function, ...)" begin
     m = Module()


### PR DESCRIPTION
This currently supports only the basic `(; a, b) = something` syntax, and does not handle the parallel function argument syntax.

~~I didn't bump the package version because I'm not sure what the release policy is but I'm happy to do that too!~~  I bumped the minor version since this is a new feature and the last merged commit was a release so it feels pretty safe.