### PR TITLE
add promoting ops for Dates.Period

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.2.0"
+version = "4.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `div`, `lcm`, `gcd`, `/`, `rem`, and `mod` will `promote` heterogenous `Dates.Period`s ([`@bdf9ead9`]). (since Compat 4.3.0)
+
 * `stack` combines a collection of slices into one array ([#43334]). (since Compat 4.2.0)
 
 * `keepat!` removes the items at all the indices which are not given and returns
@@ -153,3 +155,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#42351]: https://github.com/JuliaLang/julia/issues/42351
 [#43354]: https://github.com/JuliaLang/julia/issues/43354
 [#43334]: https://github.com/JuliaLang/julia/issues/43334
+[`@bdf9ead9`]: https://github.com/JuliaLang/julia/commit/bdf9ead91e5a8dfd91643a17c1626032faada329

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -321,8 +321,7 @@ if VERSION < v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
 end
 
 # https://github.com/JuliaLang/julia/commit/bdf9ead91e5a8dfd91643a17c1626032faada329
-# TODO: figure out correct dev version
-if VERSION < v"1.8.0"
+if VERSION < v"1.8.0-DEV.1109"
     # we do not add the methods for == and isless that are included in the above
     # commit, since they are already present in earlier versions.
     import Base: /, rem, mod, lcm, gcd, div

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -320,6 +320,18 @@ if VERSION < v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
     allequal(r::AbstractRange) = iszero(step(r)) || length(r) <= 1
 end
 
+# https://github.com/JuliaLang/julia/commit/bdf9ead91e5a8dfd91643a17c1626032faada329
+# TODO: figure out correct dev version
+if VERSION < v"1.8.0"
+    # we do not add the methods for == and isless that are included in the above
+    # commit, since they are already present in earlier versions.
+    import Base: /, rem, mod, lcm, gcd, div
+    for op in (:/, :rem, :mod, :lcm, :gcd)
+        @eval ($op)(x::Period, y::Period) = ($op)(promote(x, y)...)
+    end
+    div(x::Period, y::Period, r::RoundingMode) = div(promote(x, y)..., r)
+end
+
 # This function is available as of Julia 1.7.
 @static if !isdefined(Base, :keepat!)
     export keepat!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -556,3 +556,15 @@ end
     @test_throws ArgumentError stack([])
     @test_throws ArgumentError stack(x for x in 1:3 if false)
 end
+
+@testset "promoting ops for TimePeriod" begin
+    x = 10
+    y = 3
+    xs = Second(x)
+    ys = Second(y)
+    xms = Millisecond(xs)
+    yms = Millisecond(ys)
+    for op in (/, div, rem, mod, lcm, gcd)
+        @test op(xms, yms) == op(xms, ys) == op(xs, yms)
+    end
+end


### PR DESCRIPTION
Fixes #781 

I'm not sure how to figure out exactly which 1.8-DEV.XXX is the right version guard for this; the relevant changes were introduced in this commit: https://github.com/JuliaLang/julia/commit/bdf9ead91e5a8dfd91643a17c1626032faada329