### PR TITLE
Assume effects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.3.0"
+version = "4.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `Compat.@assume_effects setting... ex` overrides the compiler's effect modeling for the method definition `ex` on Julia versions that support this feature. Julia version without support just pass back `ex`. ([#43852]) (since Compat 4.4.0)
+
 * `div`, `lcm`, `gcd`, `/`, `rem`, and `mod` will `promote` heterogenous `Dates.Period`s ([`@bdf9ead9`]). (since Compat 4.3.0)
 
 * `stack` combines a collection of slices into one array ([#43334]). (since Compat 4.2.0)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -51,6 +51,21 @@ end
     end
 end
 
+# https://github.com/JuliaLang/julia/pull/43852
+if isdefined(Base, Symbol("@assume_effects"))
+    using Base: @assume_effects
+else
+    macro assume_effects(args...)
+        n = nfields(args)
+        call = getfield(args, n)
+        if n === 2 && getfield(args, 1) === QuoteNode(:total)
+            return esc(:(Base.@pure $(call)))
+        else
+            return esc(call)
+        end
+    end
+end
+
 if VERSION < v"1.7.0-DEV.119"
     # Part of:
     # https://github.com/JuliaLang/julia/pull/35316

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -52,7 +52,7 @@ end
 end
 
 # https://github.com/JuliaLang/julia/pull/43852
-if VERSION < v"1.8.0-DEV.1484"
+@static if VERSION < v"1.8.0-DEV.1484"
     using Base: @assume_effects
 else
     macro assume_effects(args...)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -52,7 +52,7 @@ end
 end
 
 # https://github.com/JuliaLang/julia/pull/43852
-if isdefined(Base, Symbol("@assume_effects"))
+if VERSION < v"1.8.0-DEV.1484"
     using Base: @assume_effects
 else
     macro assume_effects(args...)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -56,13 +56,7 @@ if isdefined(Base, Symbol("@assume_effects"))
     using Base: @assume_effects
 else
     macro assume_effects(args...)
-        n = nfields(args)
-        call = getfield(args, n)
-        if n === 2 && getfield(args, 1) === QuoteNode(:total)
-            return esc(:(Base.@pure $(call)))
-        else
-            return esc(call)
-        end
+        esc(last(args))
     end
 end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -53,11 +53,11 @@ end
 
 # https://github.com/JuliaLang/julia/pull/43852
 @static if VERSION < v"1.8.0-DEV.1484"
-    using Base: @assume_effects
-else
     macro assume_effects(args...)
         esc(last(args))
     end
+else
+    using Base: @assume_effects
 end
 
 if VERSION < v"1.7.0-DEV.119"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,19 +238,11 @@ end
 
 # https://github.com/JuliaLang/julia/pull/43852
 @testset "@assume_effects" begin
-    # ensure that replacing `@pure` with `@assume_effects :total` works
-    function is_total(f)
-        if isdefined(Core.Compiler, :is_total)
-            Core.Compiler.is_total(Base.infer_effects(f))
-        else
-            which(f, (Any,)).pure
-        end
-    end
-    # the compiler won't ever infer `:total` without knowledge of the inputs
-    Compat.@assume_effects :total foo(x) = x + 1
-    Compat.@assume_effects :nothrow bar(x) = x + 1
-    @test is_total(foo)
-    @test !is_total(bar)
+    # ensure proper macro hygiene across versions 
+    Compat.@assume_effects :total foo() = true
+    Compat.@assume_effects bar() = true
+    @test foo()
+    @test bar()
 end
 
 # https://github.com/JuliaLang/julia/pull/42125

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,7 +248,7 @@ end
     end
     # the compiler won't ever infer `:total` without knowledge of the inputs
     Compat.@assume_effects :total foo(x) = x + 1
-    Compat.@assume_effects bar(x) = x + 1
+    Compat.@assume_effects :nothrow bar(x) = x + 1
     @test is_total(foo)
     @test !is_total(bar)
 end


### PR DESCRIPTION
Fixes #769 

This allows packages with a 1.6 compat to replace `Base.@pure` with `Base.@assume_effects :total` similar to what's been done in base. All other effects are ignored 