### PR TITLE
Make `Dates` a weakdep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,11 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 julia = "1.6"
 
 [extras]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Dates", "Test"]
+
+[weakdeps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1,7 +1,12 @@
 module Compat
 
-import Dates
-using Dates: Period, CompoundPeriod
+if VERSION < v"1.9.0-"
+    # `Dates` is a weakdep, so won't be available on Julia versions with weakdep support,
+    # i.e. Julia 1.9 and later, so this `using` has to be inside the conditional.
+    # Should a post-1.9 feature of Dates be added to Compat, the way forward will be a
+    # package extension
+    using Dates: Period, CompoundPeriod
+end
 
 import LinearAlgebra
 


### PR DESCRIPTION
This is the little brother of #790.

It exploits that `Compat` only really needs `Dates` (to extend it) on Julia versions without weakdep support (i.e. before 1.9). So on newer Julia versions, no (unnecessary) dependence on `Dates` is introduced without loosing anything on older Julia versions.

Should a post-1.9 feature of `Dates` (or any other stdlib, actually) be added to `Compat` in the future, the way to do so is probably via a package extension (as proposed in #790), cc @oscardssmith.