### PR TITLE
[release-3] Also run CI on Julia 1.9 (backport of #787)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
           - "1.6"
           - "1.7"
           - "1.8"
+          - "~1.9.0-0"
           - nightly
         os:
           - ubuntu-latest


### PR DESCRIPTION
While the 3.x release still sees some development or at least maintenance, probably good to do thorough testing there as well.