### PR TITLE
Fix 2-arg `@inferred`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.46.1"
+version = "3.46.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -489,6 +489,8 @@ end
 # https://github.com/JuliaLang/julia/pull/27516
 if VERSION < v"1.2.0-DEV.77"
     import Test: @inferred
+    using Test: _args_and_call
+    using InteractiveUtils: gen_call_with_extracted_types
     using Core.Compiler: typesubtract
 
     macro inferred(allow, ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -492,6 +492,16 @@ end
     @test g(10) == 1
     @inferred Missing g(9)
     @inferred Missing g(10)
+
+    @testset "with kwargs (#795)" begin
+        h(a; b=1) = a < 10 ? missing : b
+        @test ismissing(h(9))
+        @test h(10) == 1
+        @inferred Missing h(9)
+        @inferred Missing h(10)
+        @inferred Missing h(9; b=2)
+        @inferred Missing h(10; b=2)
+    end
 end
 
 # https://github.com/JuliaLang/julia/pull/36360


### PR DESCRIPTION
Fixes problems with 2-args `@inferred` when the inferred call has kwargs (#795).
The problem was that the kwarg path uses non-imported calls from *Test* and *InteractiveUtils*.
Now this is fixed, and the test is added.