### PR TITLE
Add `redirect_stdio` (feature from `v1.7`)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.7.0"
+version = "4.8.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `redirect_stdio`, for simple stream redirection. ([#37978]) (since Compat 4.8.0)
+
 * `trunc`, `floor`, `ceil`, and `round` to `Bool`. ([#25085]) (since Compat 4.7.0)
 
 * `splat(f)` which is equivalent to `args -> f(args...)`. ([#42717], [#48038]) (since Compat 4.6.0) (Note: for historical reasons, `Compat` on Julia before v1.9 also exports `Splat`; its usage is discouraged, however.)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#29901]: https://github.com/JuliaLang/julia/issues/29901
 [#35316]: https://github.com/JuliaLang/julia/issues/35316
 [#36229]: https://github.com/JuliaLang/julia/issues/36229
+[#37978]: https://github.com/JuliaLang/julia/issues/37978
 [#39037]: https://github.com/JuliaLang/julia/issues/39037
 [#39245]: https://github.com/JuliaLang/julia/issues/39245
 [#39285]: https://github.com/JuliaLang/julia/issues/39285

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -657,21 +657,49 @@ if VERSION < v"1.7.0-beta1"
         stderr === nothing || redirect_stderr(stderr)
         stdout === nothing || redirect_stdout(stdout)
     end
-
-    maybe_redirect_stdin(f, ::Nothing) = f()
-    maybe_redirect_stdin(f, stream) = redirect_stdin(f, stream)
-    maybe_redirect_stderr(f, ::Nothing) = f()
-    maybe_redirect_stderr(f, stream) = redirect_stderr(f, stream)
-    maybe_redirect_stdout(f, ::Nothing) = f()
-    maybe_redirect_stdout(f, stream) = redirect_stdout(f, stream)
-
     function redirect_stdio(f; stdin=nothing, stderr=nothing, stdout=nothing)
-        maybe_redirect_stdin(stdin) do
-            maybe_redirect_stderr(stderr) do
-                maybe_redirect_stdout(stdout) do
-                    f()
-                end
-            end
+
+        function resolve(new::Nothing, oldstream, mode)
+            (new=nothing, close=false, old=nothing)
+        end
+        function resolve(path::AbstractString, oldstream,mode)
+            (new=open(path, mode), close=true, old=oldstream)
+        end
+        function resolve(new, oldstream, mode)
+            (new=new, close=false, old=oldstream)
+        end
+
+        same_path(x, y) = false
+        function same_path(x::AbstractString, y::AbstractString)
+            # if x = y = "does_not_yet_exist.txt" then samefile will return false
+            (abspath(x) == abspath(y)) || Base.Filesystem.samefile(x,y)
+        end
+        if same_path(stderr, stdin)
+            throw(ArgumentError("stdin and stderr cannot be the same path"))
+        end
+        if same_path(stdout, stdin)
+            throw(ArgumentError("stdin and stdout cannot be the same path"))
+        end
+
+        new_in , close_in , old_in  = resolve(stdin , Base.stdin , "r")
+        new_out, close_out, old_out = resolve(stdout, Base.stdout, "w")
+        if same_path(stderr, stdout)
+            # make sure that in case stderr = stdout = "same/path"
+            # only a single io is used instead of opening the same file twice
+            new_err, close_err, old_err = new_out, false, Base.stderr
+        else
+            new_err, close_err, old_err = resolve(stderr, Base.stderr, "w")
+        end
+
+        redirect_stdio(; stderr=new_err, stdin=new_in, stdout=new_out)
+
+        try
+            return f()
+        finally
+            redirect_stdio(;stderr=old_err, stdin=old_in, stdout=old_out)
+            close_err && close(new_err)
+            close_in  && close(new_in )
+            close_out && close(new_out)
         end
     end
 

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -651,7 +651,7 @@ if VERSION < v"1.8.0-beta2.17" || v"1.9.0-" <= VERSION < v"1.9.0-DEV.94"
 end
 
 # https://github.com/JuliaLang/julia/pull/37978
-if VERSION < v"1.7.0-beta1"
+if VERSION < v"1.7.0-DEV.1187"
     function redirect_stdio(;stdin=nothing, stderr=nothing, stdout=nothing)
         stdin  === nothing || redirect_stdin(stdin)
         stderr === nothing || redirect_stderr(stderr)

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -650,6 +650,34 @@ if VERSION < v"1.8.0-beta2.17" || v"1.9.0-" <= VERSION < v"1.9.0-DEV.94"
     round(::Type{Bool}, x::AbstractFloat) = (-0.5 <= x < 1.5) ? 0.5 < x : throw(InexactError(:round, Bool, x))
 end
 
+# https://github.com/JuliaLang/julia/pull/37978
+if VERSION < v"1.7.0-beta1"
+    function redirect_stdio(;stdin=nothing, stderr=nothing, stdout=nothing)
+        stdin  === nothing || redirect_stdin(stdin)
+        stderr === nothing || redirect_stderr(stderr)
+        stdout === nothing || redirect_stdout(stdout)
+    end
+
+    maybe_redirect_stdin(f, ::Nothing) = f()
+    maybe_redirect_stdin(f, stream) = redirect_stdin(f, stream)
+    maybe_redirect_stderr(f, ::Nothing) = f()
+    maybe_redirect_stderr(f, stream) = redirect_stderr(f, stream)
+    maybe_redirect_stdout(f, ::Nothing) = f()
+    maybe_redirect_stdout(f, stream) = redirect_stdout(f, stream)
+
+    function redirect_stdio(f; stdin=nothing, stderr=nothing, stdout=nothing)
+        maybe_redirect_stdin(stdin) do
+            maybe_redirect_stderr(stderr) do
+                maybe_redirect_stdout(stdout) do
+                    f()
+                end
+            end
+        end
+    end
+
+    export redirect_stdio
+end
+
 include("deprecated.jl")
 
 end # module Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -644,17 +644,11 @@ end
         println(stdout, "hello from stdout")
     end
     @testset "same path for multiple streams" begin
-        @test_throws ArgumentError redirect_stdio(hello_err_out,
-                                            stdin="samepath.txt", stdout="samepath.txt")
-        @test_throws ArgumentError redirect_stdio(hello_err_out,
-                                            stdin="samepath.txt", stderr="samepath.txt")
-
-        @test_throws ArgumentError redirect_stdio(hello_err_out,
-                                            stdin=joinpath("tricky", "..", "samepath.txt"),
-                                            stderr="samepath.txt")
         mktempdir() do dir
             path = joinpath(dir, "stdouterr.txt")
-            redirect_stdio(hello_err_out, stdout=path, stderr=path)
+            open(path, "w") do io
+                redirect_stdio(hello_err_out, stdout=io, stderr=io)
+            end
             @test read(path, String) == """
             hello from stderr
             hello from stdout
@@ -665,7 +659,9 @@ end
     mktempdir() do dir
         path_stdout = joinpath(dir, "stdout.txt")
         path_stderr = joinpath(dir, "stderr.txt")
-        redirect_stdio(hello_err_out, stderr=devnull, stdout=path_stdout)
+        open(path_stdout, "w") do io
+            redirect_stdio(hello_err_out, stderr=devnull, stdout=io)
+        end
         @test read(path_stdout, String) == "hello from stdout\n"
 
         open(path_stderr, "w") do ioerr
@@ -682,9 +678,13 @@ end
         content_stderr = randstring()
         content_stdout = randstring()
 
-        redirect_stdio(stdout=path_stdout, stderr=path_stderr) do
-            print(content_stdout)
-            print(stderr, content_stderr)
+        open(path_stderr, "w") do ioerr
+            open(path_stdout, "w") do io
+                redirect_stdio(stdout=io, stderr=ioerr) do
+                    print(content_stdout)
+                    print(stderr, content_stderr)
+                end
+            end
         end
 
         @test read(path_stderr, String) == content_stderr


### PR DESCRIPTION
From https://github.com/JuliaLang/julia/pull/37978. This completely copies the code from that PR, with one fix for `samefile` -> `Base.Filesystem.samefile`. Unit tests are copied as well.