### PR TITLE
Add `public` to the `@compat` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.9.0"
+version = "4.10.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ changes in `julia`.
 
 ## Supported features
 
-* `@public` as an alias for the `public` keyword (no-op on Julia 1.10 and earlier). ([#50105]) (since Compat 4.10.0)
+* `@compat public foo, bar` marks `foo` and `bar` as public in Julia 1.11+ and is a no-op in Julia 1.10 and earlier. ([#50105]) (since Compat 4.10.0)
 
 * `sort` for `NTuple` and other iterables. ([#46104]) (since Compat 4.9.0)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ changes in `julia`.
 
 ## Supported features
 
+* `@public` as an alias for the `public` keyword (no-op on Julia 1.10 and earlier). ([#50105]) (since Compat 4.10.0)
+
 * `sort` for `NTuple` and other iterables. ([#46104]) (since Compat 4.9.0)
 
 * `redirect_stdio`, for simple stream redirection. ([#37978]) (since Compat 4.8.0)
@@ -172,3 +174,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#43852]: https://github.com/JuliaLang/julia/issues/43852
 [#46104]: https://github.com/JuliaLang/julia/issues/46104
 [#48038]: https://github.com/JuliaLang/julia/issues/48038
+[#50105]: https://github.com/JuliaLang/julia/issues/50105

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -741,31 +741,6 @@ if VERSION < v"1.10.0-DEV.1404"
         (lt(o, y[1], x[1]) ? (y[1], merge(x, tail(y), o)...) : (x[1], merge(tail(x), y, o)...))
 end
 
-# https://github.com/JuliaLang/julia/pull/50105
-export @public
-"""
-    @public foo, bar, baz
-
-Equivalent to `public foo, bar, baz` on versions of Julia that support the `public` keyword;
-a no-op on versions of Julia that do not support the `public` keyword.
-"""
-macro public(arg)
-    symbols = _get_symbols(arg)
-    if VERSION >= v"1.11.0-DEV.469"
-        esc(Expr(:public, symbols...))
-    end
-end
-
-_get_symbols(symbol::Symbol) = (symbol,)
-function _get_symbols(symbols)
-    if symbols isa Expr && symbols.head == :tuple && all(x -> x isa Symbol, symbols.args)
-        symbols.args
-    else
-        throw(ArgumentError("cannot mark `$symbols` as public. Try `@public foo, bar, baz`."))
-    end
-end
-
-
 include("deprecated.jl")
 
 end # module Compat

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -758,7 +758,7 @@ end
 
 _get_symbols(symbol::Symbol) = (symbol,)
 function _get_symbols(symbols)
-    if Base.isexpr(symbols, :tuple) && all(x -> x isa Symbol, symbols.args)
+    if symbols isa Expr && symbols.head == :tuple && all(x -> x isa Symbol, symbols.args)
         symbols.args
     else
         throw(ArgumentError("cannot mark `$symbols` as public. Try `@public foo, bar, baz`."))

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -389,7 +389,7 @@ end
 if VERSION < v"1.9.0-DEV.1163"
     import Base: IteratorSize, HasLength, HasShape, OneTo
     export stack
-    
+
     """
         stack(iter; [dims])
 
@@ -740,6 +740,31 @@ if VERSION < v"1.10.0-DEV.1404"
     merge(x::NTuple, y::NTuple, o::Ordering) =
         (lt(o, y[1], x[1]) ? (y[1], merge(x, tail(y), o)...) : (x[1], merge(tail(x), y, o)...))
 end
+
+# https://github.com/JuliaLang/julia/pull/50105
+export @public
+"""
+    @public foo, bar, baz
+
+Equivalent to `public foo, bar, baz` on versions of Julia that support the `public` keyword;
+a no-op on versions of Julia that do not support the `public` keyword.
+"""
+macro public(arg)
+    symbols = _get_symbols(arg)
+    if VERSION >= v"1.11.0-DEV.469"
+        esc(Expr(:public, symbols...))
+    end
+end
+
+_get_symbols(symbol::Symbol) = (symbol,)
+function _get_symbols(symbols)
+    if Base.isexpr(symbols, :tuple) && all(x -> x isa Symbol, symbols.args)
+        symbols.args
+    else
+        throw(ArgumentError("cannot mark `$symbols` as public. Try `@public foo, bar, baz`."))
+    end
+end
+
 
 include("deprecated.jl")
 

--- a/src/compatmacro.jl
+++ b/src/compatmacro.jl
@@ -13,11 +13,11 @@ function _compat(ex::Expr)
     @static if VERSION < v"1.7.0-DEV.364"
         if Meta.isexpr(ex, :(=)) && Meta.isexpr(ex.args[1], :tuple) &&
             Meta.isexpr(ex.args[1].args[1], :parameters)
-            
+
             ex = _destructure_named_tuple(ex)
         end
     end
-    
+
     return Expr(ex.head, map(_compat, ex.args)...)
 end
 
@@ -38,4 +38,22 @@ function _destructure_named_tuple(ex::Expr)
     end
     push!(ex.args, values)
     return ex
+end
+
+# https://github.com/JuliaLang/julia/pull/50105
+macro compat(public::Symbol, symbols_expr::Union{Expr, Symbol})
+    public == :public || throw(ArgumentError("Invalid Syntax: `@compat $public $symbols_expr`"))
+    symbols = _get_symbols(symbols_expr)
+    if VERSION >= v"1.11.0-DEV.469"
+        esc(Expr(:public, symbols...))
+    end
+end
+
+_get_symbols(symbol::Symbol) = (symbol,)
+function _get_symbols(symbols::Expr)
+    if symbols.head == :tuple && all(x -> x isa Symbol, symbols.args)
+        symbols.args
+    else
+        throw(ArgumentError("cannot mark `$symbols` as public. Try `@compat public foo, bar`."))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -727,18 +727,19 @@ end
 
 module Mod50105
     using Compat
-    @public foo, bar, baz
+    @compat public foo, bar, baz
 end
 
 # https://github.com/JuliaLang/julia/pull/50105
-@testset "@public" begin
-    @public foo_50105
+@testset "@compat public" begin
+    @compat public foo_50105
     # foo_50105 = 4 # Uncommenting this line would cause errors due to https://github.com/JuliaLang/julia/issues/51325
     @test Base.isexported(@__MODULE__, :foo_50105) === false
     VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(@__MODULE__, :foo_50105)
     @test Base.isexported(Mod50105, :bar) === false
     VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(Mod50105, :bar)
 
-    @test_throws LoadError @eval @public 4, bar
-    @test_throws LoadError @eval @public foo bar
+    @test_throws LoadError @eval @compat public 4, bar
+    @test_throws LoadError @eval @compat public foo bar
+    @test_throws LoadError @eval @compat publac foo, bar
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -727,7 +727,7 @@ end
 
 module Mod50105
     using Compat
-    @compat public foo, bar, baz
+    @compat public foo, var"#", baz
     @compat public @mac1
     @compat public f00, @mac2, @mac3
     @compat public @mac4, @mac5
@@ -739,7 +739,7 @@ end
     # foo_50105 = 4 # Uncommenting this line would cause errors due to https://github.com/JuliaLang/julia/issues/51325
     @test Base.isexported(@__MODULE__, :foo_50105) === false
     VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(@__MODULE__, :foo_50105)
-    for sym in [:foo, :bar, :baz, Symbol("@mac1"), :f00, Symbol("@mac2"), Symbol("@mac3"), Symbol("@mac4"), Symbol("@mac5")]
+    for sym in [:foo, Symbol("#"), :baz, Symbol("@mac1"), :f00, Symbol("@mac2"), Symbol("@mac3"), Symbol("@mac4"), Symbol("@mac5")]
         @test Base.isexported(Mod50105, sym) === false
         VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(Mod50105, sym)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -728,6 +728,9 @@ end
 module Mod50105
     using Compat
     @compat public foo, bar, baz
+    @compat public @mac1
+    @compat public f00, @mac2, @mac3
+    @compat public @mac4, @mac5
 end
 
 # https://github.com/JuliaLang/julia/pull/50105
@@ -736,10 +739,18 @@ end
     # foo_50105 = 4 # Uncommenting this line would cause errors due to https://github.com/JuliaLang/julia/issues/51325
     @test Base.isexported(@__MODULE__, :foo_50105) === false
     VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(@__MODULE__, :foo_50105)
-    @test Base.isexported(Mod50105, :bar) === false
-    VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(Mod50105, :bar)
+    for sym in [:foo, :bar, :baz, Symbol("@mac1"), :f00, Symbol("@mac2"), Symbol("@mac3"), Symbol("@mac4"), Symbol("@mac5")]
+        @test Base.isexported(Mod50105, sym) === false
+        VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(Mod50105, sym)
+    end
 
     @test_throws LoadError @eval @compat public 4, bar
     @test_throws LoadError @eval @compat public foo bar
     @test_throws LoadError @eval @compat publac foo, bar
+    @test_throws LoadError @eval @compat public 4, @bar
+    @test_throws LoadError @eval @compat public foo @bar
+    @test_throws LoadError @eval @compat publac foo, @bar
+    @test_throws LoadError @eval @compat public @bar, 4
+    @test_throws LoadError @eval @compat public @bar foo
+    @test_throws LoadError @eval @compat publac @bar, foo
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,7 +238,7 @@ end
 
 # https://github.com/JuliaLang/julia/pull/43852
 @testset "@assume_effects" begin
-    # ensure proper macro hygiene across versions 
+    # ensure proper macro hygiene across versions
     Compat.@assume_effects :total foo() = true
     Compat.@assume_effects bar() = true
     @test foo()
@@ -723,4 +723,22 @@ end
         @test_throws ArgumentError sort("string")
         @test_throws ArgumentError("1 cannot be sorted") sort(1)
     end
+end
+
+module Mod50105
+    using Compat
+    @public foo, bar, baz
+end
+
+# https://github.com/JuliaLang/julia/pull/50105
+@testset "@public" begin
+    @public foo_50105
+    # foo_50105 = 4 # Uncommenting this line would cause errors due to https://github.com/JuliaLang/julia/issues/51325
+    @test Base.isexported(@__MODULE__, :foo_50105) === false
+    VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(@__MODULE__, :foo_50105)
+    @test Base.isexported(Mod50105, :bar) === false
+    VERSION >= v"1.11.0-DEV.469" && @test Base.ispublic(Mod50105, :bar)
+
+    @test_throws LoadError @eval @public 4, bar
+    @test_throws LoadError @eval @public foo bar
 end


### PR DESCRIPTION
The documentation included in this PR should make the PR itself self-explanatory. If it's not self-explanatory, then it's not acceptably documented.