### PR TITLE
Deprecate `sort` for `NTuple` and other iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ changes in `julia`.
 
 * `@compat public foo, bar` marks `foo` and `bar` as public in Julia 1.11+ and is a no-op in Julia 1.10 and earlier. ([#50105]) (since Compat 4.10.0)
 
-* `sort` for `NTuple` and other iterables. ([#46104]) (since Compat 4.9.0)
-
 * `redirect_stdio`, for simple stream redirection. ([#37978]) (since Compat 4.8.0)
 
 * `trunc`, `floor`, `ceil`, and `round` to `Bool`. ([#25085]) (since Compat 4.7.0)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -15,3 +15,48 @@ Base.@deprecate_binding parseatom Meta.parseatom false
 Base.@deprecate_binding parseall Meta.parseall false
 import UUIDs
 Base.@deprecate_binding uuid5 UUIDs.uuid5 true
+
+# https://github.com/JuliaLang/julia/pull/46104
+# reverted in https://github.com/JuliaLang/julia/pull/52010
+if VERSION < v"1.10.0-DEV.1404" ||
+    (VERSION >= v"1.10-rc2" && VERSION < v"1.11.0-") ||
+    VERSION >= v"1.11.0-DEV.924"
+    using Base: Ordering, Forward, ord, lt, tail, copymutable, DEFAULT_STABLE, IteratorSize, HasShape, IsInfinite
+    function Base.sort(v; kws...)
+        Base.depwarn("sorting arbitrary iterables is deprecated", :sort)
+        if v isa AbstractString
+            throw(ArgumentError("sort(::AbstractString) is not supported"))
+        end
+        if v isa NTuple
+            return _sort(v; kws...)
+        end
+        if v isa Tuple
+            throw(ArgumentError("sort(::Tuple) is only supported for NTuples"))
+        end
+        size = IteratorSize(v)
+        size == HasShape{0}() && throw(ArgumentError("$v cannot be sorted"))
+        size == IsInfinite() && throw(ArgumentError("infinite iterator $v cannot be sorted"))
+        sort!(copymutable(v); kws...)
+    end
+
+    function _sort(x::NTuple{N}; lt::Function=isless, by::Function=identity,
+                  rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where N
+        o = ord(lt,by,rev,order)
+        if N > 9
+            v = sort!(copymutable(x), DEFAULT_STABLE, o)
+            tuple((v[i] for i in 1:N)...)
+        else
+            _sort(x, o)
+        end
+    end
+    _sort(x::Union{NTuple{0}, NTuple{1}}, o::Ordering) = x
+    function _sort(x::NTuple, o::Ordering)
+        a, b = Base.IteratorsMD.split(x, Val(length(x)>>1))
+        merge(_sort(a, o), _sort(b, o), o)
+    end
+    merge(x::NTuple, y::NTuple{0}, o::Ordering) = x
+    merge(x::NTuple{0}, y::NTuple, o::Ordering) = y
+    merge(x::NTuple{0}, y::NTuple{0}, o::Ordering) = x # Method ambiguity
+    merge(x::NTuple, y::NTuple, o::Ordering) =
+        (lt(o, y[1], x[1]) ? (y[1], merge(x, tail(y), o)...) : (x[1], merge(tail(x), y, o)...))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -696,8 +696,6 @@ end
 @testset "sort(iterable)" begin
     function tuple_sort_test(x)
       @test issorted(sort(x))
-      length(x) > 9 && return # length > 9 uses a vector fallback
-      @test 0 == @allocated sort(x)
     end
     @testset "sort(::NTuple)" begin
         @test sort((9,8,3,3,6,2,0,8)) == (0,2,3,3,6,8,8,9)


### PR DESCRIPTION
As this functionality was removed from Julia in https://github.com/JuliaLang/julia/pull/52010.

CC @ericphanson