### PR TITLE
Revert "`sort` for NTuple and other iterables (#804)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.10.0"
+version = "4.10.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ changes in `julia`.
 
 * `@compat public foo, bar` marks `foo` and `bar` as public in Julia 1.11+ and is a no-op in Julia 1.10 and earlier. ([#50105]) (since Compat 4.10.0)
 
-* `sort` for `NTuple` and other iterables. ([#46104]) (since Compat 4.9.0)
-
 * `redirect_stdio`, for simple stream redirection. ([#37978]) (since Compat 4.8.0)
 
 * `trunc`, `floor`, `ceil`, and `round` to `Bool`. ([#25085]) (since Compat 4.7.0)
@@ -172,6 +170,5 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#43334]: https://github.com/JuliaLang/julia/issues/43334
 [#43354]: https://github.com/JuliaLang/julia/issues/43354
 [#43852]: https://github.com/JuliaLang/julia/issues/43852
-[#46104]: https://github.com/JuliaLang/julia/issues/46104
 [#48038]: https://github.com/JuliaLang/julia/issues/48038
 [#50105]: https://github.com/JuliaLang/julia/issues/50105

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -692,39 +692,6 @@ end
     end
 end
 
-# https://github.com/JuliaLang/julia/pull/46104
-@testset "sort(iterable)" begin
-    function tuple_sort_test(x)
-      @test issorted(sort(x))
-      length(x) > 9 && return # length > 9 uses a vector fallback
-      @test 0 == @allocated sort(x)
-    end
-    @testset "sort(::NTuple)" begin
-        @test sort((9,8,3,3,6,2,0,8)) == (0,2,3,3,6,8,8,9)
-        @test sort((9,8,3,3,6,2,0,8), by=x->x÷3) == (2,0,3,3,8,6,8,9)
-        for i in 1:40
-            tuple_sort_test(tuple(rand(i)...))
-        end
-        @test_throws ArgumentError sort((1,2,3.0))
-    end
-    @testset "sort!(iterable)" begin
-        gen = (x % 7 + 0.1x for x in 1:50)
-        @test sort(gen) == sort!(collect(gen))
-        gen = (x % 7 + 0.1y for x in 1:10, y in 1:5)
-        @test sort(gen; dims=1) == sort!(collect(gen); dims=1)
-        @test sort(gen; dims=2) == sort!(collect(gen); dims=2)
-
-        @test_throws ArgumentError("dimension out of range") sort(gen; dims=3)
-
-        @test_throws UndefKeywordError(:dims) sort(gen)
-        @test_throws UndefKeywordError(:dims) sort(collect(gen))
-        @test_throws UndefKeywordError(:dims) sort!(collect(gen))
-
-        @test_throws ArgumentError sort("string")
-        @test_throws ArgumentError("1 cannot be sorted") sort(1)
-    end
-end
-
 module Mod50105
     using Compat
     @compat public foo, var"#", baz


### PR DESCRIPTION
This reverts commit c59d116e7039db494ac61548a52651f3d8ba7b30. Closes #811.

This is likely to break NDTensors, but might still be considered a bugfix as it makes Compat behave more like most recent Julia, see discussion in #811.