### PR TITLE
test: `Fix`: adjust "structs not in `Base`" test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.18.0"
+version = "4.18.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1066,10 +1066,6 @@ end
             construction_happened::Bool = false
             struct MyStruct
                 x::Int
-                function MyStruct(x::Int)
-                    construction_happened = true
-                    new(x)
-                end
             end
             f = Fix{1}(MyStruct, 1)
             @test f isa Fix{1}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1063,7 +1063,6 @@ end
             @test_throws ArgumentError("expected type parameter in `Fix` to be `Int`, but got `1::UInt64`") Fix{UInt64(1)}(>, 1)
         end
         @testset "Specialize to structs not in `Base`" begin
-            construction_happened::Bool = false
             struct MyStruct
                 x::Int
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1063,11 +1063,18 @@ end
             @test_throws ArgumentError("expected type parameter in `Fix` to be `Int`, but got `1::UInt64`") Fix{UInt64(1)}(>, 1)
         end
         @testset "Specialize to structs not in `Base`" begin
+            construction_happened::Bool = false
             struct MyStruct
                 x::Int
+                function MyStruct(x::Int)
+                    construction_happened = true
+                    new(x)
+                end
             end
             f = Fix{1}(MyStruct, 1)
-            @test f isa Fix{1,Type{MyStruct},Int}
+            @test f isa Fix{1}
+            @test !construction_happened
+            @test (f(); construction_happened;)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1073,8 +1073,7 @@ end
             end
             f = Fix{1}(MyStruct, 1)
             @test f isa Fix{1}
-            @test !construction_happened
-            @test (f(); construction_happened;)
+            @test f() === MyStruct(1)
         end
     end
 end


### PR DESCRIPTION
* Do not test the exact return type of `Fix{1}(MyStruct, 1)`. That does not seem necessary, given that the intention behind the test is merely ensuring that `Fix` works correctly for a newly-defined `MyStruct`.

* Test that `Fix{1}(MyStruct, 1)()` calls `MyStruct(1)`.

The motivation is making PkgEval pass for PR JuliaLang/julia#59623.