### PR TITLE
Add `chopprefix`/`chopsuffix` methods for `AbstractChar` from PR 59425

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compat"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.18.1"
+version = "4.19.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ changes in `julia`.
 
 * `VersionNumber(::VersionNumber)` defined as a no-op constructor ([#45052]) (since Compat 4.12)
 
+* `chopprefix` and `chopsuffix` accept an `AbstractChar` prefix/suffix ([#59425]) (since Compat 14.19)
+
 ## Developer tips
 
 One of the most important rules for `Compat.jl` is to avoid breaking user code
@@ -205,3 +207,4 @@ Note that you should specify the correct minimum version for `Compat` in the
 [#50795]: https://github.com/JuliaLang/julia/issues/50795
 [#54653]: https://github.com/JuliaLang/julia/issues/54653
 [#58940]: https://github.com/JuliaLang/julia/issues/58940
+[#59425]: https://github.com/JuliaLang/julia/issues/59425

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1132,6 +1132,10 @@ end
 
 # https://github.com/JuliaLang/julia/pull/59425
 if VERSION < v"1.13.0-DEV.1078"
+    if VERSION >= v"1.8.0-DEV.1016"
+        # Extend from Base without qualification (avoids duplicating the definitions)
+        import Base: chopprefix, chopsuffix
+    end
     function chopprefix(s::AbstractString, prefix::AbstractChar)
         if !isempty(s) && first(s) == prefix
             return SubString(s, nextind(s, firstindex(s)))

--- a/src/Compat.jl
+++ b/src/Compat.jl
@@ -1130,6 +1130,24 @@ if VERSION < v"1.8.0-DEV.1016"
     export chopprefix, chopsuffix
 end
 
+# https://github.com/JuliaLang/julia/pull/59425
+if VERSION < v"1.13.0-DEV.1078"
+    function chopprefix(s::AbstractString, prefix::AbstractChar)
+        if !isempty(s) && first(s) == prefix
+            return SubString(s, nextind(s, firstindex(s)))
+        else
+            return SubString(s)
+        end
+    end
+    function chopsuffix(s::AbstractString, suffix::AbstractChar)
+        if !isempty(s) && last(s) == suffix
+            return SubString(s, firstindex(s), prevind(s, lastindex(s)))
+        else
+            return SubString(s)
+        end
+    end
+end
+
 if VERSION < v"1.12.0-DEV.974"  # contrib/commit-name.sh 2635dea
 
     insertdims(A; dims) = _insertdims(A, dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -907,6 +907,11 @@ end
 
         @test isa(chopprefix(S("foo"), "fo"), SubString)
         @test isa(chopsuffix(S("foo"), "oo"), SubString)
+
+        @test chopprefix(S(""), 'z') == chopsuffix(S(""), 'z') == ""
+        @test chopprefix(S("吃齋"), '🍖') == chopsuffix(S("吃齋"), '🍖') == "吃齋"
+        @test chopprefix(S("äwesome"), 'ä') == "wesome"
+        @test chopsuffix(S("äwesome"), 'e') == "äwesom"
     end
 end
 


### PR DESCRIPTION
These were added in [\#59425](https://github.com/JuliaLang/julia/pull/59425), during the 1.13 development cycle.